### PR TITLE
Add configurability to logging and other bits

### DIFF
--- a/src/re_frame/core.cljs
+++ b/src/re_frame/core.cljs
@@ -8,18 +8,18 @@
 
 ;; --  API  -------
 
-(def dispatch         router/dispatch)
-(def dispatch-sync    router/dispatch-sync)
+(def ^{:arglists '([[event-id & args] :as eventv])} dispatch router/dispatch)
+(def ^{:arglists '([[event-id & args] :as eventv])} dispatch-sync router/dispatch-sync)
 
-(def register-sub  subs/register)
-(def subscribe     subs/subscribe)
+(def ^{:arglists '([key-v handler-fn])} register-sub subs/register)
+(def ^{:arglists '([key-v])} subscribe subs/subscribe)
 
 
 
 (def pure        middleware/pure)
 (def debug       middleware/debug)
 (def undoable    middleware/undoable)
-(def path        middleware/path)
+(def ^{:arglists '([& args])} path middleware/path)
 (def enrich      middleware/enrich)
 (def trim-v      middleware/trim-v)
 (def after       middleware/after)
@@ -36,6 +36,3 @@
     (handlers/register-base id pure handler))
   ([id middleware handler]
     (handlers/register-base id [pure middleware] handler)))
-
-
-

--- a/src/re_frame/handlers.cljs
+++ b/src/re_frame/handlers.cljs
@@ -27,6 +27,11 @@
 
 (def ^:private id->fn  (atom {}))
 
+(defn clear-handlers!
+  "Unregister all event handlers.
+  May be useful for those applications using the reloaded workflow."
+  []
+  (reset! id->fn {}))
 
 (defn lookup-handler
   [event-id]

--- a/src/re_frame/middleware.cljs
+++ b/src/re_frame/middleware.cljs
@@ -2,7 +2,7 @@
   (:require
     [reagent.ratom  :refer [IReactiveAtom]]
     [re-frame.undo  :refer [store-now!]]
-    [re-frame.utils :refer [warn log dbg group groupEnd]]
+    [re-frame.utils :refer [warn log dbg]]
     [clojure.data   :as data]))
 
 
@@ -43,12 +43,10 @@
   [handler]
   (fn debug-handler
     [db v]
-    (group "re-frame event: " v)
     (let [new-db  (handler db v)
           diff    (data/diff db new-db)]
-      (log "only before: " (first diff))
-      (log "only after : " (second diff))
-      (groupEnd)
+      (log "re-frame event: only before: " (first diff))
+      (log "re-frame event: only after : " (second diff))
       new-db)))
 
 

--- a/src/re_frame/subs.cljs
+++ b/src/re_frame/subs.cljs
@@ -7,6 +7,11 @@
 ;; maps from handler-id to handler-fn
 (def ^:private key->fn (atom {}))
 
+(defn clear-subs!
+  "Unregister all subscriptions.
+  May be useful for those applications using the reloaded workflow."
+  []
+  (reset! key->fn {}))
 
 (defn register
   "register a hander function for an id"

--- a/src/re_frame/utils.cljs
+++ b/src/re_frame/utils.cljs
@@ -1,25 +1,40 @@
 (ns re-frame.utils)
 
+;; -- Logging -------------------------------------------------------------------------------------
 
-(defn warn
-  [& args]
-  (.warn js/console (apply str args)))
+(def ^:dynamic *log-level*
+  "The current log level.  Can be one of [:trace :debug :info :log :warn :error], or nil to disable.
+  Defaults to :debug.  Change with binding or set!."
+  :debug)
 
-(defn dbg
-  [& args]
-  (.debug js/console (apply str args)))
+(let [levels [:trace :debug :info :log :warn :error]
+      valid-level?   (set levels)
+      ordered-levels (zipmap levels (next (range)))
+      sufficient?    (fn [level]
+                       (and (valid-level? level) (valid-level? *log-level*)
+                            (>= (ordered-levels level) (ordered-levels *log-level*))))]
+  (def ^:dynamic *log-fn*
+    "The log function to use, takes two args:
+  
+      level - one of [:trace :debug :info :log :warn :error]
+      xs    - a collection of items to log."
+    (fn default-log-fn                                      ; Name for traces
+      [level xs]
+      (let [level      (or (valid-level? level) :log)
+            console-fn (or (aget js/console (name level)) (.-log js/console))]
+        (if (sufficient? level)
+          (.apply console-fn js/console (into-array (map str xs))))))))
 
-(defn log
-  [& args]
-  (.log js/console (apply str args)))
+(let [do-log #(if *log-fn* (*log-fn* %1 %2) nil)]
+  (defn trace [& args] (do-log :trace args))
+  (defn dbg [& args] (do-log :debug args))
+  (defn info [& args] (do-log :info args))
+  (defn log [& args] (do-log :log args))
+  (defn warn [& args] (do-log :warn args))
+  (defn error [& args] (do-log :error args)))
 
-(defn group
-  [& args]
-  (.group js/console (apply str args)))
 
-(defn groupEnd
-  []
-  (.groupEnd js/console))
+;; -- Misc ----------------------------------------------------------------------------------------
 
 (defn first-in-vector
   [v]


### PR DESCRIPTION
There's a few things here, but the main thing is logging so feel free to cherry pick.

I added the logging stuff because the console was drowning in messages about overwritten re-frame handlers every time I changed a file; it's very lightweight as you can see.  I removed the console grouping stuff, as _all_ console calls between `group()` and `groupEnd()` are gobbled up, whether generated by re-frame or not.  It's also not a standard and will blow up on, for example, IE versions older than 11.