### PR TITLE
Fixed issue with css overwriting the cljs views for "Clear completed"

### DIFF
--- a/examples/todomvc/resources/public/todos.css
+++ b/examples/todomvc/resources/public/todos.css
@@ -323,19 +323,17 @@ html #clear-completed:active {
     line-height: 20px;
     text-decoration: none;
     cursor: pointer;
-    visibility: hidden;
     position: relative;
 }
 
 #clear-completed::after {
     visibility: visible;
-    content: 'Clear completed';
     position: absolute;
     right: 0;
     white-space: nowrap;
 }
 
-#clear-completed:hover::after {
+#clear-completed:hover {
     text-decoration: underline;
 }
 

--- a/examples/todomvc/src/todomvc/views.cljs
+++ b/examples/todomvc/src/todomvc/views.cljs
@@ -42,7 +42,7 @@
            [:li (props-for :done "Completed")]]
           (when (pos? done)
             [:button#clear-completed {:on-click #(dispatch [:clear-completed])}
-             "Clear completed " done])]]))))
+             "Clear completed " #_done])]]))))
 
 (defn todo-item
   []
@@ -93,4 +93,3 @@
            [stats-footer]])]
        [:footer#info
         [:p "Double-click to edit a todo"]]])))
-


### PR DESCRIPTION
See #94.

Fixes the issue with the "Clear completed" being rendered from the css and not the cljs code and also correctly fires the event to clear todos. I think the css was a little weird for Firefox and didn't allow the event to be fired because of `visibility:none`?

Though this does not solve the issue with the view of the check-boxes in Firefox.

I wonder if this css was added for moble? Also in the cljs code it wants to render like...
"Clear completed #" I just commented the # part out. Not sure if that is wanted anymore or not.