### PR TITLE
decouple app-db and re-frame

### DIFF
--- a/src/re_frame/core.cljs
+++ b/src/re_frame/core.cljs
@@ -4,17 +4,18 @@
     [re-frame.subs       :as subs]
     [re-frame.router     :as router]
     [re-frame.utils      :as utils]
-    [re-frame.middleware :as middleware]))
-
+    [re-frame.middleware :as middleware]
+    [re-frame.db         :refer [app-db]]))
 
 ;; --  API  -------
 
 (def dispatch         router/dispatch)
-(def dispatch-sync    router/dispatch-sync)
+(def dispatch-sync    (partial router/dispatch-sync app-db))
 
 (def register-sub        subs/register)
 (def clear-sub-handlers! subs/clear-handlers!)
-(def subscribe           subs/subscribe)
+(def subscribe           (partial subs/subscribe app-db))
+(def router-loop         (partial router/router-loop app-db))
 
 
 (def clear-event-handlers!  handlers/clear-handlers!)
@@ -52,5 +53,5 @@
   ([id middleware handler]
     (handlers/register-base id [pure middleware] handler)))
 
-
-
+;; start event processing
+(router-loop)

--- a/src/re_frame/handlers.cljs
+++ b/src/re_frame/handlers.cljs
@@ -1,6 +1,5 @@
 (ns re-frame.handlers
-  (:require [re-frame.db         :refer [app-db]]
-            [re-frame.utils      :refer [first-in-vector warn error]]))
+  (:require [re-frame.utils      :refer [first-in-vector warn error]]))
 
 
 ;; -- composing middleware  -----------------------------------------------------------------------
@@ -82,7 +81,7 @@
     - the event vector
   The handler is assumed to side-effect on `app-db` - the return value is ignored.
   To write a pure handler, use the \"pure\" middleware when registering the handler."
-  [event-v]
+  [app-db event-v]
   (let [event-id    (first-in-vector event-v)
         handler-fn  (lookup-handler event-id)]
     (if (nil? handler-fn)

--- a/src/re_frame/router.cljs
+++ b/src/re_frame/router.cljs
@@ -35,14 +35,14 @@
 ;;
 
 (defn router-loop
-  []
+  [app-db]
   (go-loop []
            (let [event-v  (<! event-chan)                   ;; wait for an event
                  _        (if (:flush-dom (meta event-v))   ;; check the event for metadata
                             (do (flush) (<! (timeout 20)))  ;; wait just over one annimation frame (16ms), to rensure all pending GUI work is flushed to the DOM.
                             (<! (timeout 0)))]              ;; just in case we are handling one dispatch after an other, give the browser back control to do its stuff
              (try
-               (handle event-v)
+               (handle app-db event-v)
 
                ;; If the handler throws:
                ;;   - allow the exception to bubble up because the app, in production,
@@ -55,15 +55,11 @@
                (catch js/Object e
                  (do
                    ;; try to recover from this (probably uncaught) error as best we can
-                   (purge-chan)        ;; get rid of any pending events
-                   (router-loop)       ;; Exception throw will cause termination of go-loop. So, start another.
+                   (purge-chan)         ;; get rid of any pending events
+                   (router-loop app-db) ;; Exception throw will cause termination of go-loop. So, start another.
 
                    (throw e)))))        ;; re-throw so the rest of the app's infrastructure (window.onerror?) gets told
            (recur)))
-
-;; start event processing
-(router-loop)
-
 
 ;; -- dispatch ------------------------------------------------------------------------------------
 
@@ -86,8 +82,8 @@
 
   Usage example:
      (dispatch-sync [:delete-item 42])"
-  [event-v]
-  (handle event-v)
+  [app-db event-v]
+  (handle app-db event-v)
   nil)    ;; Ensure nil return. See https://github.com/Day8/re-frame/wiki/Beware-Returning-False
 
 

--- a/src/re_frame/subs.cljs
+++ b/src/re_frame/subs.cljs
@@ -1,7 +1,6 @@
 (ns re-frame.subs
  (:require
    [reagent.ratom  :refer [make-reaction]]
-   [re-frame.db    :refer [app-db]]
    [re-frame.utils :refer [first-in-vector warn error]]))
 
 
@@ -25,7 +24,7 @@
 
 (defn subscribe
   "Returns a reagent/reaction which observes a part of app-db"
-  [v]
+  [app-db v]
   (let [key-v       (first-in-vector v)
         handler-fn  (get @key->fn key-v)]
     (if (nil? handler-fn)


### PR DESCRIPTION
This is just a proposal PR. I wasn't able to run tests (OS X) or update examples. I can put more work into this if the general idea is approved.

In [Plastic](https://github.com/darwin/plastic) I had to vendor re-frame, because I wanted to use my own app-db and router. Unfortunately `router.cljs`, `handlers.cljs` and `subs.cljs` are requiring re-frame's `db.cljs` directly which didn't give me a chance to cherry-pick them independently.

This PR removes direct dependency of `router.cljs`, `handlers.cljs` and `subs.cljs` on `db.cljs`. To preserve backward compatibility this dependency is moved to `core.cljs` which should be used as public api by majority of re-frame consumers anyways.

The second change is making automatic start of router loop optional. Again, it was moved to `core.cljs`. Library consumers who will not include `core.cljs` can still include `router.cljs` and kick-start router loop by calling  `(router-loop some-app-db)` manually (or provide their own).

This PR does not touch `undo.cljs` because it is not exposed via `core.cljs`, I'm afraid decoupling it from app-db would break current API. Anyways, I don't need re-frame's undo at this point