### PR TITLE
Added a space to make list in README.md appear

### DIFF
--- a/README.md
+++ b/README.md
@@ -1019,6 +1019,7 @@ Second, remind yourself that the `combining function` of a `reduce` takes two pa
 2. the next collection member to fold in.
 
 Then notice that event handlers take two parameters too:
+
 1. the current state of `app-db`
 2. the next item to fold in.
 


### PR DESCRIPTION
Just added a space to make a list. I do have a questions about lists in general. Some times a list item is capitalized but more often it is not even if the point is a sentence. Would you mind if I got though and apply what's recommend in [this english.stackoverflow](http://english.stackexchange.com/a/55049) response?