### PR TITLE
Fix behavior with large undo lists

### DIFF
--- a/src/re_frame/undo.cljs
+++ b/src/re_frame/undo.cljs
@@ -53,10 +53,10 @@
   "Stores the value currently in app-db, so the user can later undo"
   [explanation]
   (clear-redos!)
-  (reset! undo-list (vec (take
+  (reset! undo-list (vec (take-last
                            @max-undos
                            (conj @undo-list @app-db))))
-  (reset! undo-explain-list (vec (take
+  (reset! undo-explain-list (vec (take-last
                                    @max-undos
                                    (conj @undo-explain-list @app-explain))))
   (reset! app-explain explanation))


### PR DESCRIPTION
Hello!

It seems like undo doesn't work with large undo lists, because you always grab first 50 elements of a vector. I have tried "undo" in my application and have got wrong results.

Please, fix me if I didn't understand the idea correctly.