### PR TITLE
Update terms used in Elm to latest changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ again, and then into further computations, etc.  "Values" flow (propagate) throu
 But this Signal graph must be without cycles, because cycles cause mayhem!  re-frame achieves
 a unidirectional flow.
 
-While the mechanics are different, `reaction` has the intent of `lift` in [Elm] and `defc=` in [Hoplon].
+While the mechanics are different, `reaction` has the intent of `map` in [Elm] and `defc=` in [Hoplon].
 
 Right, so that was a lot of words. Some code to clarify:
 


### PR DESCRIPTION
Since Elm 0.14, there is no more `lift`. Fixed it to `map`.

> The term lift is dead. It makes me a bit sad for my thesis, but I think it will help a lot of people get started with signals more quickly. The new term is map, and the goal is to build on the intuition people have from working with lists.

http://elm-lang.org/blog/announce/0.14