### PR TITLE
Insignificant typo correction in console output

### DIFF
--- a/src/re_frame/subs.cljs
+++ b/src/re_frame/subs.cljs
@@ -67,7 +67,7 @@
          cached)
      (let [query-id   (first-in-vector query-v)
            handler-fn (get @qid->fn query-id)]
-       (console :warn "Subscription crerated: " query-v)
+       (console :warn "Subscription created: " query-v)
        (if-not handler-fn
          (console :error "re-frame: no subscription handler registered for: \"" query-id "\". Returning a nil subscription."))
        (cache-and-return query-v [] (handler-fn app-db query-v)))))


### PR DESCRIPTION
Might bother only me, and I need to move to the new `def-sub` anyway, but hey!