### PR TITLE
Lower logging levels of normal events

### DIFF
--- a/src/re_frame/loggers.cljc
+++ b/src/re_frame/loggers.cljc
@@ -4,10 +4,10 @@
    #?@(:clj [[clojure.string :as str]
              [clojure.tools.logging :as log]])))
 
-(defn log [level & args]
-  (log/log level (if (= 1 (count args))
-                   (first args)
-                   (str/join " " (map pr-str args)))))
+#?(:clj (defn log [level & args]
+          (log/log level (if (= 1 (count args))
+                           (first args)
+                           (str/join " " args)))))
 
 ;; "loggers" holds the current set of logging functions.
 ;; By default, re-frame uses the functions provided by js/console.

--- a/src/re_frame/subs.cljc
+++ b/src/re_frame/subs.cljc
@@ -39,7 +39,7 @@
   (let [cache-key [query-v dynv]]
     ;; when this reaction is nolonger being used, remove it from the cache
     (add-on-dispose! r #(do (swap! query->reaction dissoc cache-key)
-                            (console :warn "Removing subscription: " cache-key)))
+                            (console :log "Removing subscription: " cache-key)))
 
     (console :log "Dispatch site: ")
     (console :log (:dispatch-site (meta query-v)))
@@ -62,18 +62,18 @@
   "Returns a Reagent/reaction which contains a computation"
   ([query-v]
    (if-let [cached (cache-lookup query-v)]
-     (do (console :warn "Using cached subscription: " query-v)
+     (do (console :log "Using cached subscription: " query-v)
          cached)
      (let [query-id   (first-in-vector query-v)
            handler-fn (get @qid->fn query-id)]
-       (console :warn "Subscription created: " query-v)
+       (console :log "Subscription created: " query-v)
        (if-not handler-fn
          (console :error "re-frame: no subscription handler registered for: \"" query-id "\". Returning a nil subscription."))
        (cache-and-return query-v [] (handler-fn app-db query-v)))))
 
   ([v dynv]
    (if-let [cached (cache-lookup v dynv)]
-     (do (console :warn "Using cached subscription: " v " and " dynv)
+     (do (console :log "Using cached subscription: " v " and " dynv)
          cached)
      (let [query-id   (first-in-vector v)
            handler-fn (get @qid->fn query-id)]
@@ -86,7 +86,7 @@
                sub (make-reaction (fn [] (handler-fn app-db v @dyn-vals)))]
            ;; handler-fn returns a reaction which is then wrapped in the sub reaction
            ;; need to double deref it to get to the actual value.
-           (console :warn "Subscription created: " v dynv)
+           (console :log "Subscription created: " v dynv)
            (cache-and-return v dynv (make-reaction (fn [] @@sub)))))))))
 
 ;; -- Helper code for register-pure -------------------


### PR DESCRIPTION
We don't need to use the :warn logging level for standard events.