### PR TITLE
Fix never-ending warn about not implementing IReactiveAtom

### DIFF
--- a/src/re_frame/subs.cljs
+++ b/src/re_frame/subs.cljs
@@ -79,7 +79,7 @@
      (let [query-id   (first-in-vector v)
            handler-fn (get @qid->fn query-id)]
        (when ^boolean js/goog.DEBUG
-         (when-let [not-reactive (remove #(implements? reagent.ratom/IReactiveAtom %) dynv)]
+         (when-let [not-reactive (not-empty (remove #(implements? reagent.ratom/IReactiveAtom %) dynv))]
            (console :warn "re-frame: your subscription's dynamic parameters that don't implement IReactiveAtom: " not-reactive)))
        (if (nil? handler-fn)
          (console :error "re-frame: no subscription handler registered for: \"" query-id "\". Returning a nil subscription.")


### PR DESCRIPTION
Currently whenever you have the console open you get a warning about some arguments not implementing IReactiveAtom. After a lot of time trying to track down where the problem lay I realised that my code was fine, and the warning is always printed with an empty list.

Hope this helps
Oliy