### PR TITLE
Bugfix: path and fx handler

### DIFF
--- a/src/re_frame/std_interceptors.cljc
+++ b/src/re_frame/std_interceptors.cljc
@@ -164,11 +164,11 @@
                  (let [db-store     (db-store-key context)
                        original-db  (peek db-store)
                        new-db-store (pop db-store)
-                       full-db      (->> (get-effect context :db)
-                                         (assoc-in original-db path))]
-                   (-> context
-                       (assoc db-store-key new-db-store)
-                       (assoc-effect :db full-db)))))))
+                       new-context  (assoc context db-store-key new-db-store)]
+                   (if-let [new-db-at-path (get-effect context :db)]
+                     (let [full-db (assoc-in original-db path new-db-at-path)]
+                       (assoc-effect new-context :db full-db))
+                     new-context))))))
 
 
 


### PR DESCRIPTION
If there is no `:db` effect produced by an effectful handler (presumably
because the handler is concerned with some other form of side-effect
than a DB update), then the `path` interceptor should not attempt to
update the DB value it returns.