### PR TITLE
Keep JVM thread bindings on next-tick

### DIFF
--- a/src/re_frame/interop.clj
+++ b/src/re_frame/interop.clj
@@ -24,7 +24,8 @@
 (defonce ^:private executor (Executors/newSingleThreadExecutor))
 
 (defn next-tick [f]
-  (.execute executor f)
+  (let [bound-f (bound-fn [& args] (apply f args))]
+    (.execute executor bound-f))
   nil)
 
 (def empty-queue clojure.lang.PersistentQueue/EMPTY)


### PR DESCRIPTION
... to enable clojure.test reporting to identify the current test.