### PR TITLE
Remove trailing spaces from console logging

### DIFF
--- a/src/re_frame/events.cljc
+++ b/src/re_frame/events.cljc
@@ -20,14 +20,14 @@
       (make-chain interceptors)
       (do    ;; do a whole lot of development time checks
         (when-not (coll? interceptors)
-          (console :error  "re-frame: when registering " id ", expected a collection of interceptors, got: " interceptors))
+          (console :error (str "re-frame: when registering " id ", expected a collection of interceptors, got:") interceptors))
         (let [chain (make-chain interceptors)]
           (when (empty? chain)
-            (console :error  "re-frame: when registering " id ", given an empty interceptor chain"))
+            (console :error (str "re-frame: when registering" id ", given an empty interceptor chain")))
           (when-let [not-i (first (remove interceptor/interceptor? chain))]
             (if (fn? not-i)
-              (console :error  "re-frame: when registering " id ", got a function instead of an interceptor. Did you provide old style middleware by mistake? Got: " not-i)
-              (console :error  "re-frame: when registering " id ", expected interceptors, but got: " not-i)))
+              (console :error (str "re-frame: when registering " id ", got a function instead of an interceptor. Did you provide old style middleware by mistake? Got:") not-i)
+              (console :error (str "re-frame: when registering " id ", expected interceptors, but got:") not-i)))
           chain)))))
 
 
@@ -54,7 +54,7 @@
   (let [event-id  (first-in-vector event-v)]
     (if-let [interceptors  (get-handler kind event-id true)]
       (if *handling*
-        (console :error "re-frame: while handling \""  *handling* "\"  dispatch-sync was called for \"" event-v "\". You can't call dispatch-sync within an event handler.")
+        (console :error (str "re-frame: while handling \"" *handling* "\", dispatch-sync was called for \"" event-v "\". You can't call dispatch-sync within an event handler."))
         (binding [*handling*  event-v]
           (interceptor/execute event-v interceptors))))))
 

--- a/src/re_frame/fx.cljc
+++ b/src/re_frame/fx.cljc
@@ -56,7 +56,7 @@
   (fn [value]
     (doseq  [{:keys [ms dispatch] :as effect} value]
         (if (or (empty? dispatch) (-> ms number? not))
-          (console :error "re-frame: ignoring bad :dispatch-later value: " effect)
+          (console :error "re-frame: ignoring bad :dispatch-later value:" effect)
           (set-timeout! #(router/dispatch dispatch) ms)))))
 
 
@@ -71,7 +71,7 @@
   :dispatch
   (fn [value]
     (if-not (vector? value)
-      (console :error "re-frame: ignoring bad :dispatch value. Expected a vector, but got: " value)
+      (console :error "re-frame: ignoring bad :dispatch value. Expected a vector, but got:" value)
       (router/dispatch value))))
 
 
@@ -87,7 +87,7 @@
   :dispatch-n
   (fn [value]
     (if-not (sequential? value)
-      (console :error "re-frame: ignoring bad :dispatch-n value. Expected a collection, got got: " value))
+      (console :error "re-frame: ignoring bad :dispatch-n value. Expected a collection, got got:" value))
     (doseq [event value] (router/dispatch event))))
 
 

--- a/src/re_frame/interceptor.cljc
+++ b/src/re_frame/interceptor.cljc
@@ -25,7 +25,7 @@
     (if-let [unknown-keys  (seq (clojure.set/difference
                              (-> (dissoc m :name) keys set)         ;; XXX take out name in due course
                              mandatory-interceptor-keys))]
-      (console :error "re-frame: ->interceptor " m " has unknown keys: " unknown-keys)))
+      (console :error "re-frame: ->interceptor " m " has unknown keys:" unknown-keys)))
   {:id     (or id name :unnamed)     ;; XXX remove `name` in due course
    :before before
    :after  after })

--- a/src/re_frame/registrar.cljc
+++ b/src/re_frame/registrar.cljc
@@ -28,7 +28,7 @@
    (let [handler (get-handler kind id)]
      (when debug-enabled?
        (when (and required? (nil? handler))
-         (console :error "re-frame: no " (str kind) " handler registered for: " id)))
+         (console :error "re-frame: no " (str kind) " handler registered for:" id)))
      handler)))
 
 
@@ -36,7 +36,7 @@
   [kind id handler-fn]
   (when debug-enabled?
     (when (get-handler kind id false)
-      (console :warn "re-frame: overwriting " (str kind) " handler for: " id)))   ;; allow it, but warn. Happens on figwheel reloads.
+      (console :warn "re-frame: overwriting" (str kind) "handler for:" id)))   ;; allow it, but warn. Happens on figwheel reloads.
   (swap! kind->id->handler assoc-in [kind id] handler-fn)
   handler-fn)    ;; note: returns the just registered handler
 
@@ -53,4 +53,4 @@
    (assert (kinds kind))
    (if (get-handler kind id)
      (swap! kind->id->handler update-in [kind] dissoc id)
-     (console :warn "re-frame: can't clear " (str kind) " handler for  " id ".  Not found."))))
+     (console :warn "re-frame: can't clear" (str kind) "handler for" (str id ". Handler not found.")))))

--- a/src/re_frame/router.cljc
+++ b/src/re_frame/router.cljc
@@ -102,13 +102,13 @@
   ;; register a callback function which will be called after each event is processed
   (add-post-event-callback [_ id callback-fn]
     (if (contains? post-event-callback-fns id)
-      (console :warn "re-frame: overwriting existing post event call back with id: " id))
+      (console :warn "re-frame: overwriting existing post event call back with id:" id))
     (->> (assoc post-event-callback-fns id callback-fn)
          (set! post-event-callback-fns)))
 
   (remove-post-event-callback [_ id]
     (if-not (contains? post-event-callback-fns id)
-      (console :warn "re-frame: could not remove post event call back with id: " id)
+      (console :warn "re-frame: could not remove post event call back with id:" id)
       (->> (dissoc post-event-callback-fns id)
            (set! post-event-callback-fns))))
 

--- a/src/re_frame/std_interceptors.cljc
+++ b/src/re_frame/std_interceptors.cljc
@@ -29,7 +29,7 @@
     :id     :debug
     :before (fn debug-before
               [context]
-              (console :log "Handling re-frame event: " (get-coeffect context :event))
+              (console :log "Handling re-frame event:" (get-coeffect context :event))
               context)
     :after  (fn debug-after
               [context]
@@ -37,15 +37,15 @@
                     orig-db        (get-coeffect context :db)
                     new-db         (get-effect   context :db  ::not-found)]
                 (if (= new-db ::not-found)
-                  (console :log "No :db changes caused by: " event)
+                  (console :log "No :db changes caused by:" event)
                   (let [[only-before only-after] (data/diff orig-db new-db)
                         db-changed?    (or (some? only-before) (some? only-after))]
                     (if db-changed?
-                      (do (console :group "db clojure.data/diff for: " event)
-                          (console :log "only before: " only-before)
-                          (console :log "only after : " only-after)
+                      (do (console :group "db clojure.data/diff for:" event)
+                          (console :log "only before:" only-before)
+                          (console :log "only after :" only-after)
                           (console :groupEnd))
-                      (console :log "no app-db changes caused by: " event))))
+                      (console :log "no app-db changes caused by:" event))))
                 context))))
 
 

--- a/src/re_frame/subs.cljc
+++ b/src/re_frame/subs.cljc
@@ -36,7 +36,7 @@
   (let [cache-key [query-v dynv]]
     ;; when this reaction is nolonger being used, remove it from the cache
     (add-on-dispose! r #(do (swap! query->reaction dissoc cache-key)
-                            #_(console :log "Removing subscription: " cache-key)))
+                            #_(console :log "Removing subscription:" cache-key)))
     ;; cache this reaction, so it can be used to deduplicate other, later "=" subscriptions
     (swap! query->reaction assoc cache-key r)
     r))  ;; return the actual reaction
@@ -60,7 +60,7 @@
            handler-fn (get-handler kind query-id)]
        ;(console :log "Subscription created: " query-v)
        (if-not handler-fn
-         (console :error "re-frame: no subscription handler registered for: \"" query-id "\". Returning a nil subscription."))
+         (console :error (str "re-frame: no subscription handler registered for: \"" query-id "\". Returning a nil subscription.")))
        (cache-and-return query-v [] (handler-fn app-db query-v)))))
 
   ([v dynv]
@@ -71,9 +71,9 @@
            handler-fn (get-handler kind query-id)]
        (when debug-enabled?
          (when-let [not-reactive (not-empty (remove ratom? dynv))]
-           (console :warn "re-frame: your subscription's dynamic parameters that don't implement IReactiveAtom: " not-reactive)))
+           (console :warn "re-frame: your subscription's dynamic parameters that don't implement IReactiveAtom:" not-reactive)))
        (if (nil? handler-fn)
-         (console :error "re-frame: no subscription handler registered for: \"" query-id "\". Returning a nil subscription.")
+         (console :error (str "re-frame: no subscription handler registered for: \"" query-id "\". Returning a nil subscription."))
          (let [dyn-vals (make-reaction (fn [] (mapv deref dynv)))
                sub (make-reaction (fn [] (handler-fn app-db v @dyn-vals)))]
            ;; handler-fn returns a reaction which is then wrapped in the sub reaction
@@ -144,7 +144,7 @@
                          ;; a single `inputs` fn
                          1  (let [f (first input-args)]
                               (when-not (fn? f)
-                                (console :error err-header "2nd argument expected to be an inputs function, got: " f))
+                                (console :error err-header "2nd argument expected to be an inputs function, got:" f))
                               f)
 
                          ;; one sugar pair
@@ -158,7 +158,7 @@
                                vecs    (map last pairs)
                                ret-val (map subscribe vecs)]
                            (when-not (every?  vector? vecs)
-                             (console :error err-header "expected pairs of :<- and vectors, got: " pairs))
+                             (console :error err-header "expected pairs of :<- and vectors, got:" pairs))
                            (fn inp-fn
                              ([_] ret-val)
                              ([_ _] ret-val))))]

--- a/src/re_frame/utils.cljc
+++ b/src/re_frame/utils.cljc
@@ -7,5 +7,5 @@
   [v]
   (if (vector? v)
     (first v)
-    (console :error "re-frame: expected a vector, but got: " v)))
+    (console :error "re-frame: expected a vector, but got:" v)))
 


### PR DESCRIPTION
console.log and family provide spaces between arguments, so we don't need to add them in our console errors. This is how it looks currently: 

<img width="508" alt="screenshot of google chrome 22-08-16 4-10-14 pm" src="https://cloud.githubusercontent.com/assets/811954/17843511/f76f265e-6882-11e6-95e7-12b928cbad65.png">
