### PR TITLE
Add missing handler to "Loading Initial Data" doc

### DIFF
--- a/docs/Loading-Initial-Data.md
+++ b/docs/Loading-Initial-Data.md
@@ -135,6 +135,11 @@ quick sketch of the entire pattern. It is very straight-forward.
   :initialised?          ;; usage (subscribe [:initialised?])
   (fn  [db _]
 	(not (empty? db))))  ;; do we have data
+	
+(re-frame/reg-event-db
+   :initialise-db
+   (fn [db _]
+       (assoc db :display-name "Jane Doe")))
 
 (defn main-panel    ;; the top level of our app 
   []


### PR DESCRIPTION
"The pattern" implies `:initialise-db` handler, but it is missing. This PR adds a very simple implementation.