### PR TITLE
Fix typo in a link to Effectful Handlers doc

### DIFF
--- a/docs/Talking-To-Servers.md
+++ b/docs/Talking-To-Servers.md
@@ -104,7 +104,7 @@ well salted paper cut. We try hard to avoid them.
 ### Version 2 
 
 The better solution is, of course, to use an effectful handler. This 
-is explained in detail in the previous tutorials: [Effectful Handlers](EffectfulHandler.md) 
+is explained in detail in the previous tutorials: [Effectful Handlers](EffectfulHandlers.md) 
 and [Effects](Effects.md).  
 
 In the 2nd version, we use the alternative registration function, `reg-event-fx` , and we'll use an 


### PR DESCRIPTION
The title says it all. Again, very minor; sorry for PR spam.