### PR TITLE
Add elfeed-cljsrn app to docs/External-Resources

### DIFF
--- a/docs/External-Resources.md
+++ b/docs/External-Resources.md
@@ -18,6 +18,8 @@ Templates, examples, and other resources related to re-frame. For additions or m
 
 ### Examples and Applications Using re-frame
 
+* [Elfeed-cljsrn](https://github.com/areina/elfeed-cljsrn) by [Toni Reina] - A mobile client for [Elfeed](https://github.com/skeeto/elfeed) rss reader, built with React Native. Based on re-frame `0.8.0`
+
 * [Memory Hole](https://github.com/yogthos/memory-hole) by [Yogthos] - A small issue tracking app written with Luminus and re-frame. Based on re-frame `0.8.0`
 
 * [Crossed](https://github.com/velveteer/crossed/) by [Velveteer] - A multiplayer crossword puzzle generator. Based on re-frame `0.7.0`


### PR DESCRIPTION
Hi!

I would like to add this application to the external-resources document. Maybe it could be useful as a reference for people learning re-frame, or trying to build an application with React Native and Clojurescript. 
It's based on re-frame 0.8.0 and as interesting points, it's using `async-flow-fx` and `http-fx` effect handlers.

Thank you!