### PR TITLE
Call after interceptor with db coeffect, if no db effect is produced

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,9 @@
-## 0.8.1  (2016.08.XX)  Unreleased
-
+## 0.8.1 Unreleased
 
 #### Improvements
 
-  - [#200](https://github.com/Day8/re-frame/pull/200) Remove trailing spaces from console logging 
+- [#200](https://github.com/Day8/re-frame/pull/200) Remove trailing spaces from console logging 
+- [#248](https://github.com/Day8/re-frame/pull/200) Provide after interceptor with `db` coeffect, if no `db` effect was produced.
 
 ## 0.8.0  (2016.08.19)
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject re-frame "0.8.1"
+(defproject re-frame "0.8.1-SNAPSHOT"
   :description  "A Clojurescript MVC-like Framework For Writing SPAs Using Reagent."
   :url          "https://github.com/Day8/re-frame.git"
   :license      {:name "MIT"}
@@ -65,4 +65,5 @@
 
   :aliases {"test-once"   ["do" "clean," "cljsbuild" "once" "test," "shell" "open" "test/test.html"]
             "test-auto"   ["do" "clean," "cljsbuild" "auto" "test,"]
-            "karma-once"  ["do" "clean," "cljsbuild" "once" "karma,"]})
+            "karma-once"  ["do" "clean," "cljsbuild" "once" "karma,"]
+            "karma-auto"  ["do" "clean," "cljsbuild" "auto" "karma,"]})

--- a/src/re_frame/interceptor.cljc
+++ b/src/re_frame/interceptor.cljc
@@ -109,7 +109,7 @@
   "Add a collection of `interceptors` to the end of `context's` execution `:queue`.
   Returns the updated `context`.
 
-  In an advanced case, this function would allow an interceptor could add new
+  In an advanced case, this function could allow an interceptor to add new
   interceptors to the `:queue` of a context."
   [context interceptors]
   (update context :queue

--- a/src/re_frame/std_interceptors.cljc
+++ b/src/re_frame/std_interceptors.cljc
@@ -218,8 +218,9 @@
   "Interceptor factory which runs a given function `f` in the \"after\"
   position, presumably for side effects.
 
-  `f` is called with two arguments: the `effects` value of `:db` and the event. It's return
-  value is ignored so `f` can only side-effect.
+  `f` is called with two arguments: the `effects` value of `:db`
+  (or the `coeffect` value of db if no db effect is returned) and the event.
+   Its return value is ignored so `f` can only side-effect.
 
   Example use:
      - `f` runs schema validation (reporting any errors found)
@@ -229,7 +230,9 @@
     :id    :after
     :after (fn after-after
              [context]
-             (let [db    (get-effect context :db)
+             (let [db    (or (get-effect context :db)
+                             ;; If no db effect is returned, we provide the original coeffect.
+                             (get-coeffect context :db))
                    event (get-coeffect context :event)]
                (f db event)    ;; call f for side effects
                context))))     ;; context is unchanged

--- a/test/re-frame/interceptor_test.cljs
+++ b/test/re-frame/interceptor_test.cljs
@@ -1,9 +1,10 @@
 (ns re-frame.interceptor-test
   (:require [cljs.test :refer-macros [is deftest]]
-            [reagent.ratom  :refer [atom]]
+            [reagent.ratom :refer [atom]]
             [re-frame.interceptor :refer [context get-coeffect assoc-effect assoc-coeffect get-effect]]
-            [re-frame.std-interceptors :refer [trim-v path on-changes
-                                               db-handler->interceptor fx-handler->interceptor]]))
+            [re-frame.std-interceptors :refer [trim-v path on-changes after
+                                               db-handler->interceptor fx-handler->interceptor]]
+            [re-frame.interceptor :as interceptor]))
 
 (enable-console-print!)
 
@@ -116,4 +117,12 @@
                 (get-effect :db))))))
 
 
-
+(deftest test-after
+  (let [after-db-val (atom nil)]
+    (-> (context [:a :b]
+                 [(after (fn [db] (reset! after-db-val db)))]
+                 {:a 1})
+        (interceptor/invoke-interceptors :before)
+        interceptor/change-direction
+        (interceptor/invoke-interceptors :after))
+    (is (= @after-db-val {:a 1}))))


### PR DESCRIPTION
`after` interceptors expect to always get a db value. If no db effect is produced, then they may fail (for example schema validation on db if no db is provided).

Fixes #239