### PR TITLE
Added :response-format, without that it fails.

### DIFF
--- a/docs/Talking-To-Servers.md
+++ b/docs/Talking-To-Servers.md
@@ -128,6 +128,7 @@ Here's our rewrite:
     ;; we return a map of (side) effects
     {:http-xhrio {:method          :get
                   :uri             "http://json.my-endpoint.com/blah"
+                  :response-format (ajax/json-response-format {:keywords? true})  ;; <-- this is very important, don't forget to require [ajax.core :as ajax]
                   :on-success      [:process-response]
                   :on-failure      [:bad-response]}
      :db  (assoc db :loading? true)}))

--- a/docs/Talking-To-Servers.md
+++ b/docs/Talking-To-Servers.md
@@ -117,6 +117,7 @@ Here's our rewrite:
 ```clj
 (ns my.app.events                  
    (:require
+      [ajax.core :as ajax]        
       [day8.re-frame.http-fx]  
       [re-frame.core :refer [reg-event-fx]))
 
@@ -128,7 +129,7 @@ Here's our rewrite:
     ;; we return a map of (side) effects
     {:http-xhrio {:method          :get
                   :uri             "http://json.my-endpoint.com/blah"
-                  :response-format (ajax/json-response-format {:keywords? true})  ;; <-- this is very important, don't forget to require [ajax.core :as ajax]
+                  :response-format (ajax/json-response-format {:keywords? true}) 
                   :on-success      [:process-response]
                   :on-failure      [:bad-response]}
      :db  (assoc db :loading? true)}))


### PR DESCRIPTION
Without this line the event fails as the response is not properly formatted.