### PR TITLE
Add dynamic var for warning on handler overwrite

### DIFF
--- a/examples/todomvc/project.clj
+++ b/examples/todomvc/project.clj
@@ -17,7 +17,8 @@
                                                   :source-map           true
                                                   :source-map-timestamp true
                                                   :main                 "todomvc.core"}
-                                       :figwheel {:on-jsload "todomvc.core/main"}}}}}
+                                       :figwheel {:before-jsload "todomvc.core/before_reload"
+                                                  :on-jsload "todomvc.core/figwheel_reload"}}}}}
 
              :prod {:cljsbuild
                     {:builds {:client {:compiler {:optimizations :advanced

--- a/src/re_frame/registrar.cljc
+++ b/src/re_frame/registrar.cljc
@@ -8,6 +8,7 @@
 
 ;; kinds of handlers
 (def kinds #{:event :fx :cofx :sub})
+(def ^:dynamic *warn-on-overwrite* true)
 
 ;; This atom contains a register of all handlers.
 ;; Contains a map keyed first by `kind` (of handler), and then `id`.
@@ -35,7 +36,7 @@
 (defn register-handler
   [kind id handler-fn]
   (when debug-enabled?                                       ;; This is in a separate when so Closure DCE can run
-    (when (get-handler kind id false)
+    (when (and (get-handler kind id false) *warn-on-overwrite*)
       (console :warn "re-frame: overwriting" (str kind) "handler for:" id)))   ;; allow it, but warn. Happens on figwheel reloads.
   (swap! kind->id->handler assoc-in [kind id] handler-fn)
   handler-fn)    ;; note: returns the just registered handler


### PR DESCRIPTION
When figwheel reloads code, it causes handlers to be re-registered which leads to a warning for each handler. This leads to noisy logs.  Figwheel has a :before-jsload key which can be called before it reloads application code.

This patch adds a `*warn-on-overwrite*` dynamic var, and shows how to use it in the example project.

One side effect of using this is that you will never get a warning for duplicate handlers when Figwheel is reloading. It may be possible to track how many handlers were reloaded in a particular Figwheel reload, but this would get very complex. In any case, you will still get warnings every time you refresh the browser, which should be good enough for the relatively rare case of creating duplicate handlers.

This still needs 
- [ ] tests
- [ ] a decision on where to put the dynamic var (in `re-frame.core` or elsewhere?, if in core, what about circular dependencies?)
- [ ] Recommendations on the [usage of dynamic vars](https://groups.google.com/forum/#!topic/clojurescript/0FdQB4bwtSw)
- [x] Is `:before-jsload` supported/able to be used? 
- [ ] Update changelog
- [ ] Docs on usage

Fixes #204
