### PR TITLE
Don't create subscriptions in reg-sub

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -4,6 +4,7 @@
     <option name="PER_PROJECT_SETTINGS">
       <value>
         <ClojureCodeStyleSettings>{
+  :cljs.core/with-redefs 1
   :cursive.formatting/align-binding-forms true
 }</ClojureCodeStyleSettings>
         <XML>

--- a/src/re_frame/subs.cljc
+++ b/src/re_frame/subs.cljc
@@ -143,20 +143,18 @@
                               f)
 
                          ;; one sugar pair
-                         2  (let [ret-val (subscribe (second input-args))]
-                              (fn inp-fn
-                                ([_] ret-val)
-                                ([_ _] ret-val)))
+                         2 (fn inp-fn
+                             ([_] (subscribe (second input-args)))
+                             ([_ _] (subscribe (second input-args))))
 
                          ;; multiple sugar pairs
                          (let [pairs   (partition 2 input-args)
-                               vecs    (map last pairs)
-                               ret-val (map subscribe vecs)]
+                               vecs    (map last pairs)]
                            (when-not (every?  vector? vecs)
                              (console :error err-header "expected pairs of :<- and vectors, got:" pairs))
                            (fn inp-fn
-                             ([_] ret-val)
-                             ([_ _] ret-val))))]
+                             ([_] (map subscribe vecs))
+                             ([_ _] (map subscribe vecs)))))]
     (register-handler
       kind
       query-id


### PR DESCRIPTION
This commit fixes a bug where reg-sub created subscriptions and closed over them when using the `:<- [:sub]` sugar. Now dependent subscriptions aren't created until they are needed, and they will be cleaned up correctly.

I'm not 100% sold on my tests for this behaviour, but I'm not sure how/if I want to hook into the Reagent guts to check this further.