### PR TITLE
making trim-v before/after symmetrical

### DIFF
--- a/src/re_frame/std_interceptors.cljc
+++ b/src/re_frame/std_interceptors.cljc
@@ -63,7 +63,14 @@
     :id      :trim-v
     :before  (fn trimv-before
                [context]
-               (update-in context [:coeffects :event] subvec 1))))
+               (-> context
+                   (update-in [:coeffects :event] subvec 1)
+                   (assoc-in [:coeffects ::untrimmed-event] (get-coeffect context :event))))
+    :after   (fn trimv-after
+               [context]
+               (-> context
+                   (assoc-in [:coeffects :event] (get-coeffect context ::untrimmed-event))
+                   (update :coeffects dissoc ::untrimmed-event)))))
 
 
 ;; -- Interceptor Factories - PART 1 ---------------------------------------------------------------
@@ -279,5 +286,3 @@
                       (assoc-in new-db out-path)
                       (assoc-effect context :db))
                  context)))))
-
-

--- a/test/re-frame/interceptor_test.cljs
+++ b/test/re-frame/interceptor_test.cljs
@@ -9,10 +9,13 @@
 (enable-console-print!)
 
 (deftest test-trim-v
-  (let [c  (-> (context [:a :b :c] [])
-               ((:before trim-v)))]
+  (let [ctx (context [:a :b :c] [])
+        c  ((:before trim-v) ctx)]
     (is (= (get-coeffect c :event)
-           [:b :c]))))
+           [:b :c]))
+
+    (let [c-after ((:after trim-v) c)]
+      (is (= c-after ctx)))))
 
 
 (deftest test-one-level-path
@@ -124,7 +127,6 @@
                 ((:before change-handler-i))       ;; cause change to :a
                 ((:after change-i))
                 (get-effect :db))))))
-
 
 (deftest test-after
   (testing "when no db effect is returned"


### PR DESCRIPTION
Clone of #280 for `develop` branch

Hello,

This change will put the untrimmed event vector back in the after phase, making it behave like the original middleware. This is generally a nice thing for interceptors to do, making them additive and not mutating, or at least idempotent.

This then allows other interceptors in the after phase to work better - middleware interceptors generally want to know what the event is called, because they're generic. For example, it lets me write the following improved schema check interceptor:

(defn valid-schema?
  "validate the given db, writing any problems to console.error"
  [db [event-name]]
  (let [res (s/check schema db)]
    (if (some? res)
      (.error js/console (str "schema problem after event " event-name ":" res)))))
And use it in a stack of interceptors containing trim-v, as long as it's at the end (which it generally will be, because it cleans up the signatures of my event handlers but I don't want it for my middleware interceptors):

(def my-interceptors [(after valid-schema?)
                      trim-v])