### PR TITLE
fix several typos in docs;

### DIFF
--- a/docs/Coeffects.md
+++ b/docs/Coeffects.md
@@ -212,7 +212,7 @@ know how to inject a `:blah`.
 ### Secret Interceptors
 
 In a previous tutorial we learned that `reg-events-db` 
-and `reg-events-fx` add Interceptors to front of any chain 
+and `reg-events-fx` add Interceptors to the front of any chain 
 during registration. We found they inserted an Interceptor called `do-fx`. 
 
 I can now reveal that 

--- a/docs/Debugging-Event-Handlers.md
+++ b/docs/Debugging-Event-Handlers.md
@@ -3,7 +3,7 @@
 This page describes techniques for debugging re-frame's event handlers.
 
 Event handlers are quite central to a re-frame app.  Only event handlers 
-can update `app-db`, to "step" an application "forward" from one state
+can update `app-db` to "step" an application "forward" from one state
 to the next.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -79,7 +79,7 @@ business on every single handler?  That would be very repetitive.
 Yes, you will have to put it on each handler.  And, yes, that could be repetitive,  unless 
 you take some steps.
 
-One thing you an do is to define standard interceptors the top of the `event.cljs` namespace:
+One thing you can do is to define standard interceptors at the top of the `event.cljs` namespace:
 ```clj
 (def standard-interceptors  [(when ^boolean goog.DEBUG debug)  another-interceptor])
 ```
@@ -210,7 +210,7 @@ That's handlers which take `db` and `event` arguments, and return a new `db`.
 So, they MUST return a new `db` value - which should be validated.  
 
 But what if we tried to do the same for `-fx` handlers, which return instead 
-an `effects` map which may, or may not, contain an `:db`?  Our solution would 
+an `effects` map which may, or may not, contain a `:db`?  Our solution would 
 have to allow for the absence of a new `db` value (by doing no validity check, because nothing 
 was being changed). 
 
@@ -227,4 +227,5 @@ was being changed).
         handler-fn)))
 ```
 
-Actually, it would probably be better to write an alternative `after` which 
+Actually, it would probably be better to write an alternative `after` which XXX
+TODO: finish thought

--- a/docs/Effects.md
+++ b/docs/Effects.md
@@ -88,7 +88,7 @@ X, Y or Z?
 The list of effects is long and varied, with everyone needing to use a 
 different combination.
 
-So effect handling has to be extensible. You need to a way to define 
+So effect handling has to be extensible. You need a way to define 
 your own side effects.
 
 ### Extensible Side Effects
@@ -147,7 +147,7 @@ cognitive overhead as possible for the eventual readers of your effectful code.
 
 This advice coming from the guy who named effects `fx` ... Oh, the hypocrisy.
 
-In my defence, here's the builtin effect handler for `:db`:
+In my defence, here's the built-in effect handler for `:db`:
 ```clj
 (reg-fx
   :db

--- a/docs/Subscribing-To-External-Data.md
+++ b/docs/Subscribing-To-External-Data.md
@@ -100,7 +100,7 @@ There'll be code in a minute but, first, let's describe how the subscription han
 will work: 
 
    1. Upon being required to provide items, it has to issue 
-      a query to the remote database. Perhaps this will be done via a 
+      a query to the remote database. Perhaps this will be done via
       a RESTful GET. Or via a firebase connection. Or by pushing a JSON 
       representation of the query down a websocket. Something. And it is the 
       subscription handler's job to know how it is done.  
@@ -156,7 +156,7 @@ A few things to notice:
    whatever way makes sense. Maybe it does nothing more than to `assoc` into an `app-db` path, 
    or maybe this is a rethinkdb changefeed subscription and your event handler will have to collate 
    the newly arriving data with what has previously been returned. Do what 
-   needs to be done in that event handler, so that the right data to be put into the right path.
+   needs to be done in that event handler, so that the right data will be put into the right path.
  
 3. We use Reagent's `make-reaction` function to create a reaction which will return 
    that known, particular path within `app-db` where the query results are to be placed.
@@ -205,7 +205,7 @@ In v0.8.0 of re-frame onwards, subscriptions are automatically de-duplicated.
 In prior versions, in cases where the same query is simultaneously issued 
 from multiple places, you'd want to 
 de-duplicate the queries. One possibility is to do this duplication 
-in `issue-items-query!` itself. You can count 
+in `issue-items-query!` itself. You can
 `count` the duplicate queries and only clear the data when that count goes to 0. 
 
 ### Thanks To
@@ -216,7 +216,7 @@ in `issue-items-query!` itself. You can count
 
 Event handlers do most of the heavy lifting within re-frame apps.
 
-When buttons gets clicked, or items get dragged 'n dropped, or tabs get
+When buttons get clicked, or items get dragged 'n dropped, or tabs get
 chosen, they know how to transition the app from one state 
 to the next. That's their job. And, when they make such
 a transition, it is quite reasonable to expect them to ALSO 


### PR DESCRIPTION
Note: I added a `TODO` in `docs/Debugging-Event-Handlers.md`, I think there was a clipped sentence at the end.