### PR TITLE
Missing square brackets on subscription for :name

### DIFF
--- a/docs/Loading-Initial-Data.md
+++ b/docs/Loading-Initial-Data.md
@@ -156,7 +156,7 @@ quick sketch of the entire pattern. It is very straight-forward.
 
 (defn main-panel    ;; the top level of our app 
   []
-  (let [name  (re-frame/subscribe :name)]   ;; we need there to be good data
+  (let [name  (re-frame/subscribe [:name])]   ;; we need there to be good data
     [:div "Hello " @name])))
 
 (defn top-panel    ;; this is new


### PR DESCRIPTION
I found a missing set of square brackets for a subscription and figured that fixing it will help newer users with the syntax being consistent. 