### PR TITLE
fix bug in subscribe with reactive arguments

### DIFF
--- a/src/re_frame/subs.cljc
+++ b/src/re_frame/subs.cljc
@@ -98,19 +98,19 @@
          cached)
      (let [query-id   (first-in-vector v)
            handler-fn (get-handler kind query-id)]
-         (trace/merge-trace! {:tags {:cached? false}})
+       (trace/merge-trace! {:tags {:cached? false}})
        (when debug-enabled?
          (when-let [not-reactive (not-empty (remove ratom? dynv))]
            (console :warn "re-frame: your subscription's dynamic parameters that don't implement IReactiveAtom:" not-reactive)))
-         (when-not handler-fn
-           (trace/merge-trace! {:error true})
-         (console :error (str "re-frame: no subscription handler registered for: \"" query-id "\". Returning a nil subscription."))
+       (if-not handler-fn
+         (do (trace/merge-trace! {:error true})
+             (console :error (str "re-frame: no subscription handler registered for: \"" query-id "\". Returning a nil subscription.")))
          (let [dyn-vals (make-reaction (fn [] (mapv deref dynv)))
-                 sub      (make-reaction (fn [] (handler-fn app-db v @dyn-vals)))]
+               sub      (make-reaction (fn [] (handler-fn app-db v @dyn-vals)))]
            ;; handler-fn returns a reaction which is then wrapped in the sub reaction
            ;; need to double deref it to get to the actual value.
-           ;(console :log "Subscription created: " v dynv)
-             (cache-and-return v dynv (make-reaction (fn [] @@sub))))))))))
+           ;; (console :log "Subscription created: " v dynv)
+           (cache-and-return v dynv (make-reaction (fn [] @@sub))))))))))
 
 ;; -- reg-sub -----------------------------------------------------------------
 


### PR DESCRIPTION
I'm inclined to blame this on an editor :D In general the indentation in that namespace seems a bit inconsistent.  
/via #296 