### PR TITLE
added nested Intellij project files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.idea/**/*
+**/.idea/**/*
 !.idea/codeStyleSettings.xml
 *.iml
 *.log


### PR DESCRIPTION
For if you want to start an intellij project, for instance, just in the `examples/simple/` folder, which will place a `.idea` folder at that level in the hierarchy.