### PR TITLE
Link text to cljs-devtools matchs link

### DIFF
--- a/docs/FAQs/Inspecting-app-db.md
+++ b/docs/FAQs/Inspecting-app-db.md
@@ -8,7 +8,7 @@ If at a REPL, inspect:  `re-frame.db/app-db`.
 
 If at the js console, that's `window.re_frame.db.app_db.state`.
 
-You are [using clj-devtools](https://github.com/binaryage/cljs-devtools), right? 
+You are [using cljs-devtools](https://github.com/binaryage/cljs-devtools), right? 
 If not, stop everything and immediately make that happen. 
 
 ### Better Answer


### PR DESCRIPTION
The link text and the link didn't match for cljs-devtools in FAQ 1 : )