### PR TITLE
self-host compatibility using macrovich

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
   :dependencies [[org.clojure/clojure        "1.8.0"]
                  [org.clojure/clojurescript  "1.9.227"]
                  [reagent                    "0.6.0"]
+                 [net.cgrand/macrovich "0.2.0"]
                  [org.clojure/tools.logging  "0.3.1"]]
 
   :profiles {:debug {:debug true}

--- a/src/re_frame/trace.cljc
+++ b/src/re_frame/trace.cljc
@@ -1,7 +1,10 @@
 (ns re-frame.trace
   "Tracing for re-frame.
   Alpha quality, subject to change/break at any time."
+  #?(:cljs (:require-macros [net.cgrand.macrovich :as macros]
+                            [re-frame.trace :refer [finish-trace with-trace merge-trace!]]))
   (:require [re-frame.interop :as interop]
+            #?(:clj [net.cgrand.macrovich :as macros])
             [re-frame.loggers :refer [console]]))
 
 (def id (atom 0))
@@ -40,37 +43,38 @@
    :child-of  (or child-of (:id *current-trace*))
    :start     (interop/now)})
 
-#?(:clj (defmacro finish-trace [trace]
-          `(when (is-trace-enabled?)
-             (let [end#      (interop/now)
-                   duration# (- end# (:start ~trace))]
-               (doseq [[k# cb#] @trace-cbs]
-                 (try (cb# [(assoc ~trace
+(macros/deftime
+  (defmacro finish-trace [trace]
+     `(when (is-trace-enabled?)
+        (let [end#      (interop/now)
+              duration# (- end# (:start ~trace))]
+          (doseq [[k# cb#] @trace-cbs]
+            (try (cb# [(assoc ~trace
                               :duration duration#
                               :end (interop/now))])
-                      #?(:clj (catch Exception e#
-                                (console :error "Error thrown from trace cb" k# "while storing" ~trace e#)))
-                      #?(:cljs (catch :default e#
-                                 (console :error "Error thrown from trace cb" k# "while storing" ~trace e#)))))))))
+                 #?(:clj (catch Exception e#
+                           (console :error "Error thrown from trace cb" k# "while storing" ~trace e#)))
+                 #?(:cljs (catch :default e#
+                            (console :error "Error thrown from trace cb" k# "while storing" ~trace e#))))))))
 
-#?(:clj (defmacro with-trace
-          "Create a trace inside the scope of the with-trace macro
+ (defmacro with-trace
+     "Create a trace inside the scope of the with-trace macro
 
           Common keys for trace-opts
           :op-type - what kind of operation is this? e.g. :sub/create, :render.
           :operation - identifier for the operation, for an subscription it would be the subscription keyword
           tags - a map of arbitrary kv pairs"
-          [{:keys [operation op-type tags child-of] :as trace-opts} & body]
-          `(if (is-trace-enabled?)
-             (binding [*current-trace* (start-trace ~trace-opts)]
-               (try ~@body
-                    (finally (finish-trace *current-trace*))))
-             (do ~@body))))
+     [{:keys [operation op-type tags child-of] :as trace-opts} & body]
+     `(if (is-trace-enabled?)
+        (binding [*current-trace* (start-trace ~trace-opts)]
+          (try ~@body
+               (finally (finish-trace *current-trace*))))
+        (do ~@body)))
 
-#?(:clj (defmacro merge-trace! [m]
-          ;; Overwrite keys in tags, and all top level keys.
-          `(when (is-trace-enabled?)
-             (let [new-trace# (-> (update *current-trace* :tags merge (:tags ~m))
-                                  (merge (dissoc ~m :tags)))]
-               (set! *current-trace* new-trace#))
-             nil)))
+  (defmacro merge-trace! [m]
+     ;; Overwrite keys in tags, and all top level keys.
+     `(when (is-trace-enabled?)
+        (let [new-trace# (-> (update *current-trace* :tags merge (:tags ~m))
+                             (merge (dissoc ~m :tags)))]
+          (set! *current-trace* new-trace#))
+        nil)))


### PR DESCRIPTION
This PR makes `re-frame` self-host compatible.
It means that `re-frame` can now be used inside KLIPSE  (which is going super useful for sharing bugs, ideas and more...).
#
Here is a [live demo](http://app.klipse.tech/?container&cljs_in.gist=viebel/e82b197907a7117f72f1a0b9a4a56303).

Note: The self-host compatibility of `re-frame` depends on the self-host compatibility of `re-agent` that is achieved by   https://github.com/reagent-project/reagent/pull/283
![image](https://cloud.githubusercontent.com/assets/955710/23827328/f3b17460-06b9-11e7-8782-f9b9c98cd1ff.png)
.