### PR TITLE
Fix for example: Request format is mandatory

### DIFF
--- a/docs/Talking-To-Servers.md
+++ b/docs/Talking-To-Servers.md
@@ -143,6 +143,7 @@ Here's our rewrite:
     ;; we return a map of (side) effects
     {:http-xhrio {:method          :get
                   :uri             "http://json.my-endpoint.com/blah"
+                  :format          (ajax/json-request-format)
                   :response-format (ajax/json-response-format {:keywords? true}) 
                   :on-success      [:process-response]
                   :on-failure      [:bad-response]}


### PR DESCRIPTION
The example in Talking-To-Servers.md is missing an mandatory parameter.

Like documented in the example: https://github.com/Day8/re-frame-http-fx#step-2-registration-and-use