### PR TITLE
Removed duplicated require causing build error with shadow-build

### DIFF
--- a/src/re_frame/interceptor.cljc
+++ b/src/re_frame/interceptor.cljc
@@ -1,8 +1,7 @@
 (ns re-frame.interceptor
   (:require
-    [re-frame.interop :refer [ratom?]]
     [re-frame.loggers :refer [console]]
-    [re-frame.interop :refer [empty-queue debug-enabled?]]))
+    [re-frame.interop :refer [ratom? empty-queue debug-enabled?]]))
 
 
 (def mandatory-interceptor-keys #{:id :after :before})


### PR DESCRIPTION
This double `:require` was causing an error and blocking the build when compiling cljs with [Shadow Build](https://github.com/thheller/shadow-build)
> ExceptionInfo NS:re-frame.interceptor has duplicate require/use for re-frame.interop  clojure.core/ex-info (core.clj:4725)  

Merging them into one fixed it.