### PR TITLE
Don't run on-changes if db is not in effects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix `re-frame.std-interceptors/on-changes` to work even if effect handler does not set `:db`. [#341](https://github.com/Day8/re-frame/pull/341)
+
 #### Breaking (previously undefined behaviour)
 
 - `reg-sub` enforces using `:<-` to indicate subscription inputs. Previously any keyword would have worked here. While using anything other than `:<-` was undefined behaviour previously, this could possibly break some code when upgrading. Thanks to [@Sohalt](https://github.com/Sohalt) [#336](https://github.com/Day8/re-frame/pull/336).

--- a/src/re_frame/std_interceptors.cljc
+++ b/src/re_frame/std_interceptors.cljc
@@ -294,7 +294,9 @@
                    ;; work out if any "inputs" have changed
                    new-ins      (map #(get-in new-db %) in-paths)
                    old-ins      (map #(get-in old-db %) in-paths)
-                   changed-ins? (some false? (map identical? new-ins old-ins))]
+                   ;; make sure the db is actually set in the effect
+                   changed-ins? (and (contains? (get-effect context) :db)
+                                     (some false? (map identical? new-ins old-ins)))]
 
                ;; if one of the inputs has changed, then run 'f'
                (if changed-ins?

--- a/test/re-frame/interceptor_test.cljs
+++ b/test/re-frame/interceptor_test.cljs
@@ -106,14 +106,15 @@
                     (get-effect))]
     (is (= e {:db 5 :dispatch [:a]}))))
 
-
-
 (deftest test-on-changes
   (let [change-handler-i  (->  (fn [db v] (assoc db :a 10))
                                db-handler->interceptor)
 
         no-change-handler-i  (->  (fn [db v] db)
                                db-handler->interceptor)
+
+        no-db-handler-i (-> (fn [ctx v] {})
+                            fx-handler->interceptor)
 
         change-i   (on-changes + [:c] [:a] [:b])
         orig-db    {:a 0 :b 2}]
@@ -127,7 +128,13 @@
             (-> (context [] [] orig-db)
                 ((:before change-handler-i))       ;; cause change to :a
                 ((:after change-i))
-                (get-effect :db))))))
+                (get-effect :db))))
+
+    (is (=  ::not-found
+            (-> (context [] [] orig-db)
+                ((:before no-db-handler-i))       ;; no db effect in context
+                ((:after change-i))
+                (get-effect :db ::not-found))))))
 
 (deftest test-after
   (testing "when no db effect is returned"


### PR DESCRIPTION
Currently, if there the effect handler does not set `:db`, then `on-changes` will end up treating `new-db` as `nil` and probably end up wiping the `db`. This causes the `on-changes` interceptor not to run if the `:db` is not set in the effect.