### PR TITLE
Remove extraneous code in todomvc sample

### DIFF
--- a/examples/todomvc/src/todomvc/views.cljs
+++ b/examples/todomvc/src/todomvc/views.cljs
@@ -55,7 +55,7 @@
         [:input#toggle-all
           {:type "checkbox"
            :checked all-complete?
-           :on-change #(dispatch [:complete-all-toggle (not all-complete?)])}]
+           :on-change #(dispatch [:complete-all-toggle])}]
         [:label
           {:for "toggle-all"}
           "Mark all as complete"]


### PR DESCRIPTION
The event handler for :complete-all-toggle doesn't appear to require any info from the event vector, yet code that dispatches to it in the task-list component makes it look otherwise.