### PR TITLE
Add jvm interop handlers for dispose! and add-on-dispose!

### DIFF
--- a/test/re-frame/subs_test.cljs
+++ b/test/re-frame/subs_test.cljs
@@ -98,6 +98,22 @@
     (subs/subscribe [:side-effecting-handler :a]) ;; this should be handled by cache
     (is (= @side-effect-atom 2))))
 
+;============== test clear-subscription-cache! ================
+
+(deftest test-clear-subscription-cache!
+  (re-frame/reg-sub
+   :clear-subscription-cache!
+   (fn clear-subs-cache [db _] 1))
+
+  (testing "cold cache"
+    (is (nil? (subs/cache-lookup [:clear-subscription-cache!]))))
+  (testing "cache miss"
+    (is (= 1 @(subs/subscribe [:clear-subscription-cache!])))
+    (is (some? (subs/cache-lookup [:clear-subscription-cache!]))))
+  (testing "clearing"
+    (subs/clear-subscription-cache!)
+    (is (nil? (subs/cache-lookup [:clear-subscription-cache!])))))
+
 ;============== test register-pure macros ================
 
 (deftest test-reg-sub-macro


### PR DESCRIPTION
Added a couple of interop handlers to try and replicate reagent's disposal behavior on the JVM as per @danielcompton 's recommendation in #385. 

It was initially assumed that atoms did not need to implement this behavior since there are no real reactions and thus no retention cycles on the JVM, but the subscription cache relies on the `on-dispose` callbacks to clear the cache entry for that _reaction_. This behavior is also relied on in `subs/clear-subscription-cache!` which is essentially a no-op for the JVM on master now.

I also added a test for `subs/clear-subscription-cache!` which, although it doesn't actually test the code in this PR, should do so when the test suite is ported to cljc.