### PR TITLE
Introduce app-global-interceptors

### DIFF
--- a/examples/todomvc/src/todomvc/events.cljs
+++ b/examples/todomvc/src/todomvc/events.cljs
@@ -2,7 +2,7 @@
   (:require
     [todomvc.db    :refer [default-db todos->local-store]]
     [re-frame.core :refer [reg-event-db reg-event-fx inject-cofx path trim-v
-                           after debug]]
+                           after debug append-app-global-interceptor-tail]]
     [cljs.spec     :as s]))
 
 
@@ -58,9 +58,12 @@
 (def todo-interceptors [check-spec-interceptor               ;; ensure the spec is still valid  (after)
                         (path :todos)                        ;; 1st param to handler will be the value from this path within db
                         ->local-store                        ;; write todos to localstore  (after)
-                        (when ^boolean js/goog.DEBUG debug)  ;; look at the js browser console for debug logs
-                        trim-v])                             ;; removes first (event id) element from the event vec
+                        trim-v])                            ;;  removes first (event id) element from the event vec
 
+;; global config, setting global interceptors for all handlers
+;; look at the js browser console for debug logs
+(when ^boolean js/goog.DEBUG
+  (append-app-global-interceptor-tail debug))
 
 ;; -- Helpers -----------------------------------------------------------------
 


### PR DESCRIPTION
Container and API to add application global interceptors to all events
without the need to define them on the `reg-event-` functions.

Adding interceptors an the `reg-event-` functions is still possible
for fine grained control.

`re-frame.core` is refactored to use the new API to add its own global
interceptors and also the interceptor section is moved to the top of
the namespace.

The example todomvc app make use of the new API to add the `debug`
interceptor to all event handlers.

`app-global-interceptors` is a map that contains two vectors under the
keywords `:head`  and `:tail`.

Interceptors in the head vector come before the event interceptors, interceptors in
the tail vector come after. Event interceptors in this context are the ones defined in
`reg-event-` functions.

This is a bit drafty but communicates my intentions I suppose. Let me know what you think.

If in favour I will add notes to the changelog and figure out how to add tests for this although not really sure about the latter.