### PR TITLE
Log warning when tracing not enabled

### DIFF
--- a/src/re_frame/trace.cljc
+++ b/src/re_frame/trace.cljc
@@ -27,7 +27,9 @@
   "Registers a tracing callback function which will receive a collection of one or more traces.
   Will replace an existing callback function if it shares the same key."
   [key f]
-  (swap! trace-cbs assoc key f))
+  (if trace-enabled?
+    (swap! trace-cbs assoc key f)
+    (console :warn "Tracing is not enabled. Please set {\"re_frame.trace.trace_enabled_QMARK_\" true} in :closure-defines. See: https://github.com/Day8/re-frame-trace#installation.")))
 
 (defn remove-trace-cb [key]
   (swap! trace-cbs dissoc key)


### PR DESCRIPTION
- problem: when people want to use tracing and forget to set closure-defines, traces don't show up and no errors or warnings are being displayed
- solution: check if tracing is enabled. if not, log warning message when opening trace panel  
- fixes #384