### PR TITLE
Do not test if on-stop before calling it

### DIFF
--- a/examples/todomvc/src/todomvc/views.cljs
+++ b/examples/todomvc/src/todomvc/views.cljs
@@ -7,7 +7,7 @@
 (defn todo-input [{:keys [title on-save on-stop]}]
   (let [val  (reagent/atom title)
         stop #(do (reset! val "")
-                  (when on-stop (on-stop)))
+                  (on-stop))
         save #(let [v (-> @val str str/trim)]
                 (when (seq v) (on-save v))
                 (stop))]


### PR DESCRIPTION
The test may not be needed as we always call `todo-input` with an `on-stop` value.

I'm not 100% sure on this one, but I tested it.