### PR TITLE
fix ns typo in sample code

### DIFF
--- a/docs/Subscribing-To-External-Data.md
+++ b/docs/Subscribing-To-External-Data.md
@@ -135,7 +135,7 @@ Enough fluffing about with words, here's a code sketch for our subscription hand
        (let  [query-token (issue-items-query!
                             type
                             :on-success #(re-frame/dispatch [:write-to  [:some :path]]))]
-         (reagent/make-reaction
+         (reagent.ratom/make-reaction
            (fn [] (get-in @app-db [:some :path] []))
            :on-dispose #(do (terminate-items-query! query-token)
                             (re-frame/dispatch [:cleanup [:some :path]]))))))


### PR DESCRIPTION
Typo fix: wrong namespace for make-reaction