### PR TITLE
Make subs only remove self from subscription cache when disposing

### DIFF
--- a/checkouts/re-frame-trace
+++ b/checkouts/re-frame-trace
@@ -1,0 +1,1 @@
+../../re-frame-trace/

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject re-frame "0.10.3-alpha1"
+(defproject re-frame "0.10.3-SNAPSHOT"
   :description  "A Clojurescript MVC-like Framework For Writing SPAs Using Reagent."
   :url          "https://github.com/Day8/re-frame.git"
   :license      {:name "MIT"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject re-frame "0.10.3-SNAPSHOT"
+(defproject re-frame "0.10.3-alpha1"
   :description  "A Clojurescript MVC-like Framework For Writing SPAs Using Reagent."
   :url          "https://github.com/Day8/re-frame.git"
   :license      {:name "MIT"}

--- a/src/re_frame/subs.cljc
+++ b/src/re_frame/subs.cljc
@@ -54,7 +54,11 @@
                                                      (dissoc query-cache cache-key)
                                                      query-cache)))))
     ;; cache this reaction, so it can be used to deduplicate other, later "=" subscriptions
-    (swap! query->reaction assoc cache-key r)
+    (swap! query->reaction (fn [query-cache]
+                             (when debug-enabled?
+                               (when (contains? query-cache cache-key)
+                                 (console :warn "re-frame: Adding a new subscription to the cache while there is an existing subscription in the cache" cache-key)))
+                             (assoc query-cache cache-key r)))
     (trace/merge-trace! {:tags {:reaction (reagent-id r)}})
     r)) ;; return the actual reaction
 

--- a/src/re_frame/subs.cljc
+++ b/src/re_frame/subs.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.subs
  (:require
    [re-frame.db        :refer [app-db]]
-   [re-frame.interop   :refer [add-on-dispose! debug-enabled? make-reaction ratom? deref? dispose! reagent-id]]
+   [re-frame.interop   :refer [add-on-dispose! debug-enabled? make-reaction ratom? deref? dispose! reagent-id ratom]]
    [re-frame.loggers   :refer [console]]
    [re-frame.utils     :refer [first-in-vector]]
    [re-frame.registrar :refer [get-handler clear-handlers register-handler]]
@@ -15,7 +15,7 @@
 ;; De-duplicate subscriptions. If two or more equal subscriptions
 ;; are concurrently active, we want only one handler running.
 ;; Two subscriptions are "equal" if their query vectors test "=".
-(def query->reaction (atom {}))
+(def query->reaction (ratom {}))
 
 (defn clear-subscription-cache!
   "Causes all subscriptions to be removed from the cache.


### PR DESCRIPTION
Adds a check for subscriptions to make sure that when they are dissocing their cache key from the query cache that they are only removing themselves. In certain cases when reloading/re-rendering the app, subscriptions would be created and destroyed several times because each version of subscription destroyed the following one.

I still need to review this more before merging.