### PR TITLE
move seq test into individual save callbacks to differentiate handling of blanks

### DIFF
--- a/examples/todomvc/src/todomvc/views.cljs
+++ b/examples/todomvc/src/todomvc/views.cljs
@@ -9,7 +9,7 @@
         stop #(do (reset! val "")
                   (when on-stop (on-stop)))
         save #(let [v (-> @val str str/trim)]
-                (when (seq v) (on-save v))
+                (on-save v)
                 (stop))]
     (fn [props]
       [:input (merge props
@@ -44,7 +44,9 @@
           [todo-input
             {:class "edit"
              :title title
-             :on-save #(dispatch [:save id %])
+             :on-save #(if (seq %)
+                          (dispatch [:save id %])
+                          (dispatch [:delete-todo id]))
              :on-stop #(reset! editing false)}])])))
 
 
@@ -91,7 +93,8 @@
     [todo-input
       {:id "new-todo"
        :placeholder "What needs to be done?"
-       :on-save #(dispatch [:add-todo %])}]])
+       :on-save #(when (seq %)
+                    (dispatch [:add-todo %]))}]])
 
 
 (defn todo-app


### PR DESCRIPTION
The todo-mvc example has a serious deviation from the official spec which says existing todos, if edited to be blank, should be deleted. The app instead treats it as an NOP, leaving the todo unchanged.

This is not a bug, but the re-frame todo-mvc is offered as an exemplar (and the fix is trivial -- pass the value through to the two on-save handlers and adjusting them so they can implement their varying behaviors) so it might be worth conforming to the spec.