### PR TITLE
Fix typo in sample code for 'reg-sub-raw' reaction fn

### DIFF
--- a/docs/Subscribing-To-External-Data.md
+++ b/docs/Subscribing-To-External-Data.md
@@ -136,7 +136,7 @@ Enough fluffing about with words, here's a code sketch for our subscription hand
                             type
                             :on-success #(re-frame/dispatch [:write-to  [:some :path]]))]
          (reagent.ratom/make-reaction
-           (fn [] (get-in @app-db [:some :path] []))
+           (fn [] (get-in @app-db [:some :path]))
            :on-dispose #(do (terminate-items-query! query-token)
                             (re-frame/dispatch [:cleanup [:some :path]]))))))
 ```


### PR DESCRIPTION
Sample code in the `docs/Subscribing-To-External-Data.md` page has a typo that prevents the example from working.

A simple change makes the example functional:

```
(re-frame/reg-sub-raw
  :items
  (fn [app-db [_ type]]
       (let  [query-token (issue-items-query!
                            type
                            :on-success #(re-frame/dispatch [:write-to  [:some :path]]))]
         (reagent.ratom/make-reaction
           ;------------ the line below should be (fn [] (get-in @app-db [:some :path]))      
           (fn [] (get-in @app-db [:some :path] []))
           :on-dispose #(do (terminate-items-query! query-token)
                            (re-frame/dispatch [:cleanup [:some :path]]))))))
``` 