### PR TITLE
Fix re-frame.interop/now for nodejs

### DIFF
--- a/src/re_frame/interop.cljs
+++ b/src/re_frame/interop.cljs
@@ -38,7 +38,9 @@
   (js/setTimeout f ms))
 
 (defn now []
-  (if (exists? js/performance.now)
+  (if (and
+       (exists? js/performance)
+       (exists? js/performance.now))
     (js/performance.now)
     (js/Date.now)))
 


### PR DESCRIPTION
In a nodejs environment`js/performance` is not defined by default and would need `perf_hooks` to be required. See https://nodejs.org/api/all.html#perf_hooks_performance_timing_api

This is quick fix to make `re-frame.interop/now` not crash when it hasn't been required.

I'm not sure if there are any tests to be written as per the contributing guidelines for re-frame in a nodejs env?