### PR TITLE
Invoke 'after' and 'enrich' interceptors only when context contains effects db. [fixes #447]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
-
+#### Fixed
+  - [#447](https://github.com/Day8/re-frame/issues/447) After interceptor runs against coeffect db if effect db is nil/false. 
 
 ## 0.10.5 (2018.02.13)
 

--- a/src/re_frame/std_interceptors.cljc
+++ b/src/re_frame/std_interceptors.cljc
@@ -282,9 +282,10 @@
     :after (fn enrich-after
              [context]
              (let [event (get-coeffect context :event)
-                   db    (or (get-effect context :db)
-                             ;; If no db effect is returned, we provide the original coeffect.
-                             (get-coeffect context :db))]
+                   db    (if (contains? (get-effect context) :db)
+                           (get-effect context :db)
+                           ;; If no db effect is returned, we provide the original coeffect.
+                           (get-coeffect context :db))]
                (->> (f db event)
                     (assoc-effect context :db))))))
 
@@ -306,9 +307,11 @@
     :id    :after
     :after (fn after-after
              [context]
-             (let [db    (or (get-effect context :db)
-                             ;; If no db effect is returned, we provide the original coeffect.
-                             (get-coeffect context :db))
+             (let [db    (if (contains? (get-effect context) :db)
+                           (get-effect context :db)
+                           ;; If no db effect is returned, we provide the original coeffect.
+                           (get-coeffect context :db))
+
                    event (get-coeffect context :event)]
                (f db event)    ;; call f for side effects
                context))))     ;; context is unchanged

--- a/src/re_frame/std_interceptors.cljc
+++ b/src/re_frame/std_interceptors.cljc
@@ -278,15 +278,15 @@
   each time. This may be a very satisfactory trade-off in many cases."
   [f]
   (->interceptor
-    :id    :enrich
+    :id :enrich
     :after (fn enrich-after
              [context]
-             ;; enrich only when :db changes
-             (cond-> context
-               (contains? (get-effect context) :db)
-               (assoc-effect
-                :db
-                (f (get-effect context :db) (get-coeffect context :event)))))))
+             (let [event (get-coeffect context :event)
+                   db    (if (contains? (:effects context) :db)
+                           (get-effect context :db) ;; If no db effect is returned, we provide the original coeffect.
+                           (get-coeffect context :db))]
+               (->> (f db event)
+                    (assoc-effect context :db))))))
 
 
 
@@ -303,13 +303,15 @@
      - `f` writes to localstorage."
   [f]
   (->interceptor
-    :id    :after
+    :id :after
     :after (fn after-after
              [context]
-             ;; call f for side effects only when :db changes
-             (when (contains? (get-effect context) :db)
-               (f (get-effect context :db) (get-coeffect context :event)))
-             context)))     ;; context is unchanged
+             (let [db    (if (contains? (:effects context) :db)
+                           (get-in context [:effects :db])
+                           (get-in context [:coeffects :db]))
+                   event (get-in context [:coeffects :event])]
+               (f db event) ;; call f for side effects
+               context)))) ;; context is unchanged
 
 
 (defn  on-changes

--- a/test/re_frame/interceptor_test.cljs
+++ b/test/re_frame/interceptor_test.cljs
@@ -145,13 +145,29 @@
           (interceptor/invoke-interceptors :before)
           interceptor/change-direction
           (interceptor/invoke-interceptors :after))
-      (is (= @after-db-val {:a 1})))))
+      (is (= @after-db-val {:a 1}))))
+  (testing "when db effect is falsey"
+    (let [ctx (context [:a :b] [] {:a 1})]
+      (-> ctx
+          (assoc-effect :db false)
+          ((:after (after (fn [db] (is (false? db)))))))
+      (-> ctx
+          (assoc-effect :db nil)
+          ((:after (after (fn [db] (is (nil? db))))))))))
 
 (deftest test-enrich
   (testing "when no db effect is returned"
     (let [ctx (context [] [] {:a 1})]
       (is (= ::not-found (get-effect ctx :db ::not-found)))
-      (-> ctx (:after (enrich (fn [db] (is (= db {:a 1})))))))))
+      (-> ctx ((:after (enrich (fn [db] (is (= db {:a 1})))))))))
+  (testing "when db effect is falsey"
+    (let [ctx (context [] [] {:a 1})]
+      (-> ctx
+          (assoc-effect :db false)
+          ((:after (enrich (fn [db] (is (false? db)))))))
+      (-> ctx
+          (assoc-effect :db nil)
+          ((:after (enrich (fn [db] (is (nil? db))))))))))
 
 (deftest test-update-coeffect
   (let [context {:effects {:db {:a 1}}

--- a/test/re_frame/interceptor_test.cljs
+++ b/test/re_frame/interceptor_test.cljs
@@ -137,17 +137,14 @@
                 (get-effect :db ::not-found))))))
 
 (deftest test-after
-  (testing "when no db effect is returned"
-    (let [after-db-val (atom nil)]
-      (-> (context [:a :b]
-                   [(after (fn [db] (reset! after-db-val db)))]
-                   {:a 1})
-          (interceptor/invoke-interceptors :before)
-          interceptor/change-direction
-          (interceptor/invoke-interceptors :after))
-      (is (= @after-db-val {:a 1}))))
-  (testing "when db effect is falsey"
-    (let [ctx (context [:a :b] [] {:a 1})]
+  (let [ctx (context [] [] {:a 1})]
+    (testing "when no db effect is returned"
+      (is
+       (-> ctx
+           ;; assert after is not invoked
+           ((:after (after (fn [db] (is false)))))
+           (= ctx))))
+    (testing "when db effect is falsey"
       (-> ctx
           (assoc-effect :db false)
           ((:after (after (fn [db] (is (false? db)))))))
@@ -156,12 +153,14 @@
           ((:after (after (fn [db] (is (nil? db))))))))))
 
 (deftest test-enrich
-  (testing "when no db effect is returned"
-    (let [ctx (context [] [] {:a 1})]
-      (is (= ::not-found (get-effect ctx :db ::not-found)))
-      (-> ctx ((:after (enrich (fn [db] (is (= db {:a 1})))))))))
-  (testing "when db effect is falsey"
-    (let [ctx (context [] [] {:a 1})]
+  (let [ctx (context [] [] {:a 1})]
+    (testing "when no db effect is returned"
+      (is
+       (-> ctx
+           ;; assert enrich is not invoked
+           ((:after (enrich (fn [db] (is false)))))
+           (= ctx))))
+    (testing "when db effect is falsey"
       (-> ctx
           (assoc-effect :db false)
           ((:after (enrich (fn [db] (is (false? db)))))))


### PR DESCRIPTION
I thought I'd grab a ticket and give you a hand! See bug for context [447](https://github.com/Day8/re-frame/issues/447)

I noticed that 'after' and 'enrich' both suffer from this issue, so I fixed them both with as little change as possible (no refactoring).

With regard to the tests, I wrote failing tests for each function, and each case, and they failed. After making them pass I noticed there was an error in an existing test case within 'test-enrich' such that it was not actually testing anything, so I fixed it as well!  You will find a comment in the review highlighting this issue.

I made reference to my fix in CHANGES.md as per the contributing instructions. If that's not how it should be done, let me know and I'll fix/remove it.