### PR TITLE
Update CodeWalkthrough.md

### DIFF
--- a/docs/CodeWalkthrough.md
+++ b/docs/CodeWalkthrough.md
@@ -30,12 +30,12 @@ Then:
   1. `git clone https://github.com/Day8/re-frame.git`
   2. `cd re-frame/examples/simple`
   3. `lein do clean, figwheel`
-  4. wait a minute and then open <http://localhost:3449/example.html>
+  4. wait a minute and then open the file `resources/public/example.html` in your browser
   
-So, what's just happened?  The ClojureScript code under `/src` has been compiled into `javascript` and
-put into `/resources/public/js/client.js` which is loaded into `/resources/public/example.html` (the HTML you just opened)
+So, what's just happened?  The ClojureScript code under `src` has been compiled into `javascript` and
+put into `resources/public/js/client.js` which is loaded into `resources/public/example.html` (the HTML file you just opened).
  
-Figwheel provides for hot-loading, so you can edit the source code (under `/src`)and watch the loaded HTML change.
+Figwheel provides for hot-loading, so you can edit the source code (under `src`)and watch the loaded HTML change.
 
 
 ## Namespace


### PR DESCRIPTION
 - Fix step #5 to open local file instead of hitting http server.
 - Make file/directory references consistent (avoid appearance they are absolute pathnames).