### PR TITLE
Prevent WARNINGs when using :infer-externs true + add deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,6 @@
+{:deps
+ {org.clojure/clojure #:mvn{:version "1.8.0"},
+  org.clojure/clojurescript #:mvn{:version "1.9.908"},
+  reagent #:mvn{:version "0.7.0"},
+  net.cgrand/macrovich #:mvn{:version "0.2.0"},
+  org.clojure/tools.logging #:mvn{:version "0.3.1"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,5 @@
-{:deps
+{:paths ["src"]
+ :deps
  {org.clojure/clojure #:mvn{:version "1.8.0"},
   org.clojure/clojurescript #:mvn{:version "1.9.908"},
   reagent #:mvn{:version "0.7.0"},

--- a/src/re_frame/interop.cljs
+++ b/src/re_frame/interop.cljs
@@ -13,7 +13,7 @@
 ;; otherwise Dead Code Elimination won't happen in `:advanced` builds.
 ;; Type hints have been liberally sprinkled.
 ;; https://developers.google.com/closure/compiler/docs/js-for-compiler
-(def ^boolean debug-enabled? "@define {boolean}" ^boolean js/goog.DEBUG)
+(def ^boolean debug-enabled? "@define {boolean}" ^boolean goog.DEBUG)
 
 (defn ratom [x]
   (reagent.core/atom x))


### PR DESCRIPTION
WARNING: target/api/inferred_externs.js:40: WARNING - name goog is not defined in the externs.
goog.DEBUG;
^^^^