### PR TITLE
Avoid running after/enrich without a db effect

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Unchanged
 
+#### Fixed
+
+  - `after` and `enrich` interceptors now no longer run if there is no `db` effect, rather than running against the `db` coffect. [#453](https://github.com/Day8/re-frame/issues/453)
 
 
 ## 0.10.6 (2018-09-03)


### PR DESCRIPTION
Previously both standard interceptors acted upon the `db` *coeffect* if
no *effect* was available. Per #453 and related discussion, there is little
reason in general to do this, since this context means that the `app-db`
should not change.

Both functions are changed to explicitly check for the presence of the
`db` effect. If it is not present in the context, the interceptor
function is not run.

The previous functionality around `nil` and `false` values for the `db`
effect is preserved: the interceptors *are* run in this case. Tests are
added where needed to verify the behavior of both functions in the case 
of non-present, falsey and truthy values.

The relevant docstrings are tweaked to accommodate this change.

Closes #453.