### PR TITLE
Improve reg-sub documentation

### DIFF
--- a/src/re_frame/subs.cljc
+++ b/src/re_frame/subs.cljc
@@ -279,9 +279,21 @@
        (fn [[a b] [_]] {:a a :b b}))
      ```
 
-     This 3rd variation is syntactic sugar for the 2nd. Pairs are supplied instead
-     of an `input signals` functions. Each pair starts with a `:<-` and a subscription
-     vector follows.
+     This 3rd variation is syntactic sugar for the 2nd.  Instead of providing an
+     `input signals` function, other subscriptions are used as automatic `input
+     signals`: Each pair of `:<-` and a subscription vector is equivalent to a call to
+     `(subscribe [:a-sub])`.
+
+     Beware that in this syntax a single `:<-` pair is *not* wrapped in a vector, hence
+     the same rule as for the 2nd variation applies: If you only provide one `input
+     signal`, the computation function must expect a single value as the 1st argument:
+
+     ```clj
+     (reg-sub
+       :a-sub
+       :<- [:a-sub]
+       (fn [a _] ...))
+     ```
 
   For further understanding, read `/docs`, and look at the detailed comments in
   /examples/todomvc/src/subs.cljs

--- a/src/re_frame/subs.cljc
+++ b/src/re_frame/subs.cljc
@@ -218,7 +218,9 @@
   a namespaced keyword.
 
   A computation function is always the last argument and it has this general form:
-    `(input-signals, query-vector) -> a-value`
+    `(input-signals, query-vector) -> a-value`.  The `query-vector` is the
+    `query` passed to `(subscribe query)` (see there for details), which may contain
+    additional arguments to further parametrise the query.
 
   What goes in between the 1st and last args can vary, but whatever is there will
   define the input signals part of the template, and, as a result, it will control

--- a/src/re_frame/subs.cljc
+++ b/src/re_frame/subs.cljc
@@ -277,9 +277,9 @@
        :<- [:b-sub]
        (fn [[a b] [_]] {:a a :b b}))
 
-  This 3rd variation is syntactic sugar for the 2nd. Pairs are supplied instead
-  of an `input signals` functions. Each pair starts with a `:<-` and a subscription
-  vector follows.
+     This 3rd variation is syntactic sugar for the 2nd. Pairs are supplied instead
+     of an `input signals` functions. Each pair starts with a `:<-` and a subscription
+     vector follows.
 
   For further understanding, read `/docs`, and look at the detailed comments in
   /examples/todomvc/src/subs.cljs

--- a/src/re_frame/subs.cljc
+++ b/src/re_frame/subs.cljc
@@ -271,11 +271,13 @@
 
   3. Syntax Sugar
 
+     ```clj
      (reg-sub
        :a-b-sub
        :<- [:a-sub]
        :<- [:b-sub]
        (fn [[a b] [_]] {:a a :b b}))
+     ```
 
      This 3rd variation is syntactic sugar for the 2nd. Pairs are supplied instead
      of an `input signals` functions. Each pair starts with a `:<-` and a subscription


### PR DESCRIPTION
Coming from #516 I tried to make the syntax sugar documentation of `reg-sub` easier to understand for newcomers.