### PR TITLE
improve convenience for deps.edn contributors

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,17 @@
+
+;; Allows users of deps.edn to more conveniently fork / make PRs to re-frame
+
+{:deps {org.clojure/clojure       {:mvn/version "1.8.0"
+                                   :scope "provided"}
+
+        org.clojure/clojurescript {:mvn/version "1.10.439"
+                                   :scope "provided"}
+
+        org.clojure/tools.logging {:mvn/version "0.4.0"}
+
+        reagent                   {:mvn/version "0.7.0"}
+
+        net.cgrand/macrovich      {:mvn/version "0.2.1"}}}
+
+
+


### PR DESCRIPTION
If you are trying to hack on `re-frame` and your project is based around `tool.deps` it's not possible to use a local-root without having a `deps.edn` file in the re-frame project.

It's not a lot of work to make that happen but this would make the process slightly more efficient.

As an added value, I would also be happy to set the project up with [lein-tools-deps](https://github.com/RickMoynihan/lein-tools-deps) if that would be interesting to the project maintainers. This approach offers a nice balance between maintaining dependencies using the new system and retaining all of the `lein` tooling that the project currently enjoys.

