### PR TITLE
Extract event from coeffects in the same place as in db-handler->inte…

### DIFF
--- a/src/re_frame/std_interceptors.cljc
+++ b/src/re_frame/std_interceptors.cljc
@@ -140,13 +140,13 @@
   :id     :fx-handler
   :before (fn fx-handler-before
             [context]
-            (let [{:keys [event] :as coeffects} (:coeffects context)
-                  new-context
+            (let [new-context
                   (trace/with-trace
                     {:op-type   :event/handler
                      :operation (get-in context [:coeffects :event])}
-                    (->> (handler-fn coeffects event)
-                         (assoc context :effects)))]
+                    (let [{:keys [event] :as coeffects} (:coeffects context)]
+                      (->> (handler-fn coeffects event)
+                           (assoc context :effects))))]
               (trace/merge-trace!
                 {:tags {:effects   (:effects new-context)
                         :coeffects (:coeffects context)}})


### PR DESCRIPTION
…rceptor

A good principle to follow in designing anything is to make things that are the
same look the same, and things that behave differently look differently.

`db-handler->interceptor` and `fx-handler->interceptor` are very similar. Their
only difference is that the latter calls the `handler-fn` with all coeffects and
assoces the result to the `:effects` key directly, whereas the former calls the
`handler-fn` with just the db from inside the coeffects, and assoces the result
to just the db in the effects.

However the code of these two functions slightly differed in *where* the event
and the db resp. the whole coeffect was extracted from the context. Eliminate
that difference so that it is clearer what's different and what's the same about
these two functions.