### PR TITLE
Consistently use (co)effect helpers

### DIFF
--- a/src/re_frame/std_interceptors.cljc
+++ b/src/re_frame/std_interceptors.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.std-interceptors
   "contains re-frame supplied, standard interceptors"
   (:require
-    [re-frame.interceptor :refer [->interceptor get-effect get-coeffect assoc-coeffect assoc-effect]]
+    [re-frame.interceptor :refer [->interceptor get-effect get-coeffect assoc-coeffect assoc-effect update-coeffect]]
     [re-frame.loggers :refer [console]]
     [re-frame.registrar :as registrar]
     [re-frame.db :refer [app-db]]
@@ -76,13 +76,13 @@
     :before  (fn trimv-before
                [context]
                (-> context
-                   (update-in [:coeffects :event] subvec 1)
-                   (assoc-in [:coeffects ::untrimmed-event] (get-coeffect context :event))))
+                   (update-coeffect :event subvec 1)
+                   (assoc-coeffect ::untrimmed-event (get-coeffect context :event))))
     :after   (fn trimv-after
                [context]
                (-> context
                    (utils/dissoc-in [:coeffects ::untrimmed-event])
-                   (assoc-in [:coeffects :event] (get-coeffect context ::untrimmed-event))))))
+                   (assoc-coeffect :event (get-coeffect context ::untrimmed-event))))))
 
 
 ;; -- Interceptor Factories - PART 1 ---------------------------------------------------------------
@@ -110,15 +110,15 @@
               (let [new-context
                     (trace/with-trace
                       {:op-type   :event/handler
-                       :operation (get-in context [:coeffects :event])}
-                      (let [{:keys [db event]} (:coeffects context)]
+                       :operation (get-coeffect context :event)}
+                      (let [{:keys [db event]} (get-coeffect context)]
                         (->> (handler-fn db event)
                              (assoc-effect context :db))))]
                 ;; We merge these tags outside of the :event/handler trace because we want them to be assigned to the parent
                 ;; wrapping trace.
                 (trace/merge-trace!
-                  {:tags {:effects   (:effects new-context)
-                          :coeffects (:coeffects context)}})
+                  {:tags {:effects   (get-effect new-context)
+                          :coeffects (get-coeffect context)}})
                 new-context))))
 
 
@@ -143,13 +143,13 @@
             (let [new-context
                   (trace/with-trace
                     {:op-type   :event/handler
-                     :operation (get-in context [:coeffects :event])}
-                    (let [{:keys [event] :as coeffects} (:coeffects context)]
+                     :operation (get-coeffect context :event)}
+                    (let [{:keys [event] :as coeffects} (get-coeffect context)]
                       (->> (handler-fn coeffects event)
                            (assoc context :effects))))]
               (trace/merge-trace!
-                {:tags {:effects   (:effects new-context)
-                        :coeffects (:coeffects context)}})
+                {:tags {:effects   (get-effect new-context)
+                        :coeffects (get-coeffect context)}})
               new-context))))
 
 
@@ -168,11 +168,11 @@
               (let [new-context
                     (trace/with-trace
                       {:op-type   :event/handler
-                       :operation (get-in context [:coeffects :event])}
+                       :operation (get-coeffect context :event)}
                       (handler-fn context))]
                 (trace/merge-trace!
-                  {:tags {:effects   (:effects new-context)
-                          :coeffects (:coeffects context)}})
+                  {:tags {:effects   (get-effect new-context)
+                          :coeffects (get-coeffect context)}})
                 new-context))))
 
 
@@ -284,7 +284,7 @@
     :after (fn enrich-after
              [context]
              (let [event (get-coeffect context :event)
-                   db    (if (contains? (:effects context) :db)
+                   db    (if (contains? (get-effect context) :db)
                            (get-effect context :db) ;; If no db effect is returned, we provide the original coeffect.
                            (get-coeffect context :db))]
                (->> (f db event)
@@ -308,10 +308,10 @@
     :id :after
     :after (fn after-after
              [context]
-             (let [db    (if (contains? (:effects context) :db)
-                           (get-in context [:effects :db])
-                           (get-in context [:coeffects :db]))
-                   event (get-in context [:coeffects :event])]
+             (let [db    (if (contains? (get-effect context) :db)
+                           (get-effect context :db)
+                           (get-coeffect context :db))
+                   event (get-coeffect context :event)]
                (f db event) ;; call f for side effects
                context)))) ;; context is unchanged
 


### PR DESCRIPTION
(Note: this builds on https://github.com/Day8/re-frame/pull/547)

In `re-frame.interceptor` there are a few functions that help you modify the
context during the processing of an event. In `re-frame.std-interceptors` these
helpers were used in some but not in all places that they can be used.

This PR changes the code so that `std-interceptors` uses these helpers where
possible.

I'm not sure these helpers are really helpful, for two reasons:

1. They are very thin wrappers around accessing the `:effects` resp.
`:coeffects` key in a context. As you can see in the diff of this pr, the
difference to using the standard clojure functions to modify a context is not
very pronounced.
2. They don't cover the following use-cases, that are taken from
`re-frame.std-interceptors`:

- dissocing a key from the coeffect. This is used in `trim-v` to restore the
  context to its original form in its `after` function. Note that the `path`
  interceptor is content with leaving its `:re-frame-path/db-store` key in the
  context.
- associng a whole effects map to the context. This is used in
  `fx-handler->interceptor` to replace the `:effects` in the context with the
  result of the call to the handler function. `db-handler->interceptor` could
  make use of the helper `assoc-effect` because it assoces just the `:db` key of
  the effect in the context.

In light of this I'd argue that the helpers don't pull their weight and
shouldn't be used.

If you agree, I can prepare a PR to that end.

Since the helpers are part of the public API, they would probably have to
remain, but their usage in `std-interceptors` can be removed.