### PR TITLE
Update simple/CodeWalkthrough.md

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Update examples/simple/CodeWalkThrough.md
 
 #### Changed
 

--- a/docs/CodeWalkthrough.md
+++ b/docs/CodeWalkthrough.md
@@ -29,7 +29,7 @@ To run the code yourself:
 Then:
   1. `git clone https://github.com/day8/re-frame.git`
   2. `cd re-frame/examples/simple`
-  3. `lein do clean, figwheel`
+  3. `lein do clean, shadow watch client`
   4. wait a minute and then open <http://localhost:3449/example.html>
   
 So, what's just happened?  The ClojureScript code under `/src` has been compiled into `javascript` and


### PR DESCRIPTION
`lein do clean, figwheel` no longer works, but `lein do clean, shadow watch client` does. Additionally, update link to http://localhost:8280/example.html as suggested by simple/README.md