### PR TITLE
Adds missing "map" in PollADatabaseEvery60.md

### DIFF
--- a/docs/FAQs/PollADatabaseEvery60.md
+++ b/docs/FAQs/PollADatabaseEvery60.md
@@ -79,8 +79,8 @@ OR, you can code defensively for reloading, perhaps like this:
   (let [live-intervals (atom {})]        ;; storage for live intervals
     (fn handler [{:keys [action id frequency event]}]     ;; the effect handler
       (condp = action
-         :clean   (doseq                ;; <--- new. clean up all existing 
-                     [_ (map #(handler {:action :end  :id  %1}) (keys @live-intervals)])
+         :clean   (doall                ;; <--- new. clean up all existing 
+                     (map #(handler {:action :end  :id  %1}) (keys @live-intervals))
          :start   (swap! live-intervals assoc id (js/setInterval #(dispatch event) frequency))) 
          :end     (do (js/clearInterval (get @live-intervals id)) 
                       (swap! live-intervals dissoc id))))

--- a/docs/FAQs/PollADatabaseEvery60.md
+++ b/docs/FAQs/PollADatabaseEvery60.md
@@ -80,8 +80,7 @@ OR, you can code defensively for reloading, perhaps like this:
     (fn handler [{:keys [action id frequency event]}]     ;; the effect handler
       (condp = action
          :clean   (doseq                ;; <--- new. clean up all existing 
-                     #(handler {:action :end  :id  %1}) 
-                     (keys @live-intervals))
+                     [_ (map #(handler {:action :end  :id  %1}) (keys @live-intervals)])
          :start   (swap! live-intervals assoc id (js/setInterval #(dispatch event) frequency))) 
          :end     (do (js/clearInterval (get @live-intervals id)) 
                       (swap! live-intervals dissoc id))))


### PR DESCRIPTION
## Core
For the defensive portion of `PollADatabaseEvery60.md`, `interval-handler` contains a `doseq`. Upon trying out the code, there is compilation problem and this is because `doseq` requires a seq of expressions. Earlier, it was missing this sequence presumably because map was missing and so no sequence was created and it failed to compile. I've added `map` and this resolves the issue.