### PR TITLE
Change out deprecated reagent/render for reagent.dom/render

### DIFF
--- a/docs/CodeWalkthrough.md
+++ b/docs/CodeWalkthrough.md
@@ -485,7 +485,7 @@ It has two tasks:
 (defn ^:export run
   []
   (rf/dispatch-sync [:initialize])     ;; puts a value into application state
-  (reagent/render [ui]              ;; mount the application's ui into '<div id="app" />'
+  (reagent.dom/render [ui]             ;; mount the application's ui into '<div id="app" />'
                   (js/document.getElementById "app")))
 ```
 

--- a/docs/Loading-Initial-Data.md
+++ b/docs/Loading-Initial-Data.md
@@ -41,7 +41,7 @@ Create a function `main` which does a `reagent/render` of your root reagent comp
 
 (defn ^:export main     ;; call this to bootstrap your app
   []
-  (reagent/render [main-panel]
+  (reagent.dom/render [main-panel]
                   (js/document.getElementById "app")))
 ```
 
@@ -101,7 +101,7 @@ We'll need to dispatch an `:initialise-db` event to get it to execute. `main` se
 (defn ^:export main
   []
   (re-frame.core/dispatch [:initialise-db])   ;;  <--- this is new 
-  (reagent/render [main-panel]
+  (reagent.dom/render [main-panel]
                   (js/document.getElementById "app")))
 ```
 
@@ -154,7 +154,7 @@ quick sketch of the entire pattern. It is very straight-forward.
 (defn ^:export main     ;; call this to bootstrap your app
   []
   (re-frame.core/dispatch [:initialise-db])
-  (reagent/render [top-panel]
+  (reagent.dom/render [top-panel]
                   (js/document.getElementById "app")))
 ```
 
@@ -172,7 +172,7 @@ Your `main` might look like this:
   (re-frame.core/dispatch [:initialise-db])           ;; basics
   (re-frame.core/dispatch [:load-from-service-1])     ;; ask for data from service-1
   (re-frame.core/dispatch [:load-from-service-2])     ;; ask for data from service-2
-  (reagent.core/render [top-panel]
+  (reagent.dom/render [top-panel]
                   (js/document.getElementById "app")))
 ```
 

--- a/examples/simple/src/simple/core.cljs
+++ b/examples/simple/src/simple/core.cljs
@@ -1,5 +1,5 @@
 (ns simple.core
-  (:require [reagent.core :as reagent]
+  (:require [reagent.dom]
             [re-frame.core :as rf]
             [clojure.string :as str]))
 
@@ -22,35 +22,35 @@
 ;; -- Domino 2 - Event Handlers -----------------------------------------------
 
 (rf/reg-event-db              ;; sets up initial application state
-  :initialize                 ;; usage:  (dispatch [:initialize])
-  (fn [_ _]                   ;; the two parameters are not important here, so use _
-    {:time (js/Date.)         ;; What it returns becomes the new application state
-     :time-color "#f88"}))    ;; so the application state will initially be a map with two keys
+ :initialize                 ;; usage:  (dispatch [:initialize])
+ (fn [_ _]                   ;; the two parameters are not important here, so use _
+   {:time (js/Date.)         ;; What it returns becomes the new application state
+    :time-color "#f88"}))    ;; so the application state will initially be a map with two keys
 
 
 (rf/reg-event-db                ;; usage:  (dispatch [:time-color-change 34562])
-  :time-color-change            ;; dispatched when the user enters a new colour into the UI text field
-  (fn [db [_ new-color-value]]  ;; -db event handlers given 2 parameters:  current application state and event (a vector)
-    (assoc db :time-color new-color-value)))   ;; compute and return the new application state
+ :time-color-change            ;; dispatched when the user enters a new colour into the UI text field
+ (fn [db [_ new-color-value]]  ;; -db event handlers given 2 parameters:  current application state and event (a vector)
+   (assoc db :time-color new-color-value)))   ;; compute and return the new application state
 
 
 (rf/reg-event-db                 ;; usage:  (dispatch [:timer a-js-Date])
-  :timer                         ;; every second an event of this kind will be dispatched
-  (fn [db [_ new-time]]          ;; note how the 2nd parameter is destructured to obtain the data value
-    (assoc db :time new-time)))  ;; compute and return the new application state
+ :timer                         ;; every second an event of this kind will be dispatched
+ (fn [db [_ new-time]]          ;; note how the 2nd parameter is destructured to obtain the data value
+   (assoc db :time new-time)))  ;; compute and return the new application state
 
 
 ;; -- Domino 4 - Query  -------------------------------------------------------
 
 (rf/reg-sub
-  :time
-  (fn [db _]     ;; db is current app state. 2nd unused param is query vector
-    (:time db))) ;; return a query computation over the application state
+ :time
+ (fn [db _]     ;; db is current app state. 2nd unused param is query vector
+   (:time db))) ;; return a query computation over the application state
 
 (rf/reg-sub
-  :time-color
-  (fn [db _]
-    (:time-color db)))
+ :time-color
+ (fn [db _]
+   (:time-color db)))
 
 
 ;; -- Domino 5 - View Functions ----------------------------------------------
@@ -83,8 +83,8 @@
 
 (defn render
   []
-  (reagent/render [ui]
-                  (js/document.getElementById "app")))
+  (reagent.dom/render [ui]
+                      (js/document.getElementById "app")))
 
 (defn ^:dev/after-load clear-cache-and-render!
   []

--- a/examples/todomvc/src/todomvc/core.cljs
+++ b/examples/todomvc/src/todomvc/core.cljs
@@ -1,7 +1,7 @@
 (ns todomvc.core
   (:require-macros [secretary.core :refer [defroute]])
   (:require [goog.events :as events]
-            [reagent.core :as reagent]
+            [reagent.dom]
             [re-frame.core :as rf :refer [dispatch dispatch-sync]]
             [secretary.core :as secretary]
             [todomvc.events] ;; These two are only required to make the compiler
@@ -47,8 +47,8 @@
   ;; Render the UI into the HTML's <div id="app" /> element
   ;; The view function `todomvc.views/todo-app` is the
   ;; root view for the entire UI.
-  (reagent/render [todomvc.views/todo-app]
-                  (.getElementById js/document "app")))
+  (reagent.dom/render [todomvc.views/todo-app]
+                      (.getElementById js/document "app")))
 
 (defn ^:dev/after-load clear-cache-and-render!
   []


### PR DESCRIPTION
reagent/render got marked deprecated [recently](https://github.com/reagent-project/reagent/commit/a8c401859d1ed4de026117c08807813aedb81f16) and causes warnings in re-frame sample applications.