### PR TITLE
chore: replace deprecated `reagent.core/render`

### DIFF
--- a/examples/simple/src/simple/core.cljs
+++ b/examples/simple/src/simple/core.cljs
@@ -1,5 +1,5 @@
 (ns simple.core
-  (:require [reagent.core :as reagent]
+  (:require [reagent.dom :as dom]
             [re-frame.core :as rf]
             [clojure.string :as str]))
 
@@ -83,7 +83,7 @@
 
 (defn render
   []
-  (reagent/render [ui]
+  (dom/render [ui]
                   (js/document.getElementById "app")))
 
 (defn ^:dev/after-load clear-cache-and-render!

--- a/examples/todomvc/src/todomvc/core.cljs
+++ b/examples/todomvc/src/todomvc/core.cljs
@@ -1,7 +1,7 @@
 (ns todomvc.core
   (:require-macros [secretary.core :refer [defroute]])
   (:require [goog.events :as events]
-            [reagent.core :as reagent]
+            [reagent.dom :as dom]
             [re-frame.core :as rf :refer [dispatch dispatch-sync]]
             [secretary.core :as secretary]
             [todomvc.events] ;; These two are only required to make the compiler
@@ -47,7 +47,7 @@
   ;; Render the UI into the HTML's <div id="app" /> element
   ;; The view function `todomvc.views/todo-app` is the
   ;; root view for the entire UI.
-  (reagent/render [todomvc.views/todo-app]
+  (dom/render [todomvc.views/todo-app]
                   (.getElementById js/document "app")))
 
 (defn ^:dev/after-load clear-cache-and-render!


### PR DESCRIPTION
see https://github.com/reagent-project/reagent/blob/master/CHANGELOG.md#0100-2020-03-06
replaced with `reagent.dom/render` in the examples