### PR TITLE
Fix some small docs typos

### DIFF
--- a/docs/correcting-a-wrong.md
+++ b/docs/correcting-a-wrong.md
@@ -1,5 +1,5 @@
 
-The "simple" app from the live coding walk through had a flaw. It brakes a rule.
+The "simple" app from the live coding walk through had a flaw. It breaks a rule.
 
 !!! Note "re-frame Rule"
     Views should only compute hiccup. A view shouldn't process input data. The subscriptions it uses should 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,13 +63,13 @@ nav:
       - "Historical": historical.md
     - More Advanced:
       - Reusable Components: reusable-components.md
-      - App Structure: app-structure.md
+      - App Structure: App-Structure.md
       - Loading Initial Data: Loading-Initial-Data.md
       - Talking To Servers: Talking-To-Servers.md
       - Subscribing to External Data: Subscribing-To-External-Data.md
       - Debugging.md
       - Testing.md
-      - Eek! Performance Problems: performance-problems.md
+      - Eek! Performance Problems: Performance-Problems.md
       - Solve the CPU hog problem: Solve-the-CPU-hog-problem.md
       - Using Stateful JS Components: Using-Stateful-JS-Components.md
       - The Logo Backstory: The-re-frame-logo.md
@@ -99,7 +99,7 @@ nav:
     - 2016: releases/2016.md
     - 2015: releases/2015.md
   - Resources:
-    - Resources: external-resources.md
+    - Resources: External-Resources.md
 
 markdown_extensions:
   - meta


### PR DESCRIPTION
I've noticed a couple of small typos, though some break of the nav.

There's a few references to `SubscriptionFlow.md` which doesn't exist in the repo too.

```
$ rg SubscriptionFlow

src/re_frame/core.cljc
267:  Docs in https://github.com/day8/re-frame/blob/master/docs/SubscriptionFlow.md"

docs/old-README.md
19:  * [Flow Mechanics](SubscriptionFlow.md)

docs/Subscribing-To-External-Data.md
137:   [See the `reg-sub-raw` docs at the end of this tutorial](SubscriptionFlow.md)

doc/cljdoc.edn
16:                          ["Flow Mechanics" {:file "docs/SubscriptionFlow.md"}]]
```