### PR TITLE
missing closing bracket in dispatch example

### DIFF
--- a/src/re_frame/core.cljc
+++ b/src/re_frame/core.cljc
@@ -33,7 +33,7 @@
   added to the end of a FIFO queue which already contain events.
 
   Usage:
-     (dispatch [:order-pizza {:supreme 2 :meatlovers 1 :veg 1})"
+     (dispatch [:order-pizza {:supreme 2 :meatlovers 1 :veg 1}])"
   [event]
   (router/dispatch event))
 


### PR DESCRIPTION
the example dispatch function [here](http://day8.github.io/re-frame/codox/re-frame.core.html#var-dispatch) is missing a closing bracket