### PR TITLE
Fix CSS to avoid codemirror block overlap

### DIFF
--- a/docs/stylesheets/codemirror.css
+++ b/docs/stylesheets/codemirror.css
@@ -242,7 +242,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   word-wrap: normal;
   line-height: inherit;
   color: inherit;
-  z-index: 2;
+  z-index: 1;
   position: relative;
   overflow: visible;
   -webkit-tap-highlight-color: transparent;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1840522/83884320-fcda4880-a744-11ea-962d-0cf3ae4a4573.png)
