### PR TITLE
Fix Basics -> Code -> Domino 2 code example

### DIFF
--- a/docs/dominoes-30k.md
+++ b/docs/dominoes-30k.md
@@ -77,7 +77,7 @@ Here's a sketch (we are at 30,000 feet):
  [coeffects event]                ;; `coeffects` holds the current state of the world
  (let [item-id   (second event)   ;; extract id from event vector
        state     (:db coeffects)  ;; extract the current application state
-       new-state (dissoc-in db [:items item-id])]   ;; new app state
+       new-state (dissoc-in state [:items item-id])]   ;; new app state
    {:db new-state}))              ;; a map of the necessary effects 
 ```
 


### PR DESCRIPTION
Database (or `db`) seems to be the preferred way to refer to the state other places in the documentation, but since the rest of the example revolved around "state" I kept that.