### PR TITLE
docs: fix improperly indented code block

### DIFF
--- a/src/re_frame/core.cljc
+++ b/src/re_frame/core.cljc
@@ -282,8 +282,8 @@
   If, on the other hand, the signal function was simpler and returned a singleton, like this:
 
       #!clj
-     (fn [query-vec dynamic-vec]
-       (subscribe [:a-sub]))      ;; <-- returning a singleton
+      (fn [query-vec dynamic-vec]
+        (subscribe [:a-sub]))      ;; <-- returning a singleton
 
   then the associated computation function must be written to expect a single value
   as the 1st argument:


### PR DESCRIPTION
Code block in docstring isn't indented properly so it isn't rendering correctly in web docs http://day8.github.io/re-frame/api-re-frame.core/#subscriptions.

![image](https://user-images.githubusercontent.com/7304317/101295298-173cce00-381d-11eb-9777-01131e3dbc52.png)
