### PR TITLE
Fix typos: it's → its

### DIFF
--- a/docs/FAQs/DoINeedReFrame.md
+++ b/docs/FAQs/DoINeedReFrame.md
@@ -73,7 +73,7 @@ another you'll be using "Reagent + a broader architecture".
 
 Hmm. I feel like I'm missing a few, but that's certainly an indicative list.
 
-re-frame is only about 750 lines of code.  So it's value is much more in the honed
+re-frame is only about 750 lines of code.  So its value is much more in the honed
 choices it embodies (and documents), than the code it provides.
 
 ## What Reagent Does Provide

--- a/src/re_frame/interceptor.cljc
+++ b/src/re_frame/interceptor.cljc
@@ -88,7 +88,7 @@
   through all interceptor functions.
 
   Generally speaking, an interceptor's `:before` function will (if present)
-  add to a `context's` `:coeffects`, while it's `:after` function
+  add to a `context's` `:coeffects`, while its `:after` function
   will modify the `context`'s `:effects`.  Very approximately.
 
   But because all interceptor functions are given `context`, and can


### PR DESCRIPTION
First ran into the docs typo when reading through the FAQ, and then decided to check all other instances of `it's` in the repo to make sure there weren’t any other cases in which the contraction (it is/it has/it was) was being used instead of the possessive.