### PR TITLE
Bring :timer snippet in sync with simple/core.cljs

### DIFF
--- a/docs/dominoes-live.md
+++ b/docs/dominoes-live.md
@@ -206,7 +206,6 @@ the application, which means they return a modified version of `db`.
   :timer
   (fn [db [_ new-time]]          ;; notice how we destructure the event vector
     (assoc db :time new-time)))  ;; compute and return the new application state
-(rf/dispatch-sync [:timer (js/Date.)])
 </code>
 
 Notes:


### PR DESCRIPTION
The line of code appears redundant as it is neither explained with an in-line comment following it nor in the notes below the snippet.
The line of code is also not present in examples/simple/src/simple/core.cljs