### PR TITLE
Fix a warning in todomvc

### DIFF
--- a/examples/todomvc/src/todomvc/core.cljs
+++ b/examples/todomvc/src/todomvc/core.cljs
@@ -36,7 +36,7 @@
 (defonce history
   (doto (History.)
     (events/listen EventType.NAVIGATE
-                   (fn [event] (secretary/dispatch! (.-token event))))
+                   (fn [^js/goog.History.Event event] (secretary/dispatch! (.-token event))))
     (.setEnabled true)))
 
 


### PR DESCRIPTION
Add a type hint to fix `Cannot infer target type in expression (. event -token)`.

I did fresh installation of java, Clojure, and Leiningen on Linux, as directed per instructions by following the links on https://github.com/day8/re-frame/tree/master/examples/todomvc.

Leiningen version:
`Leiningen 2.9.5 on Java 11.0.10 OpenJDK 64-Bit Server VM`

When running `lein watch`, I get this at the end of the output, and the warning is there on every file save:

```
[:client] Configuring build.
[:client] Compiling ...
[:client] Build completed. (216 files, 1 compiled, 1 warnings, 3.03s)

------ WARNING #1 - :infer-warning ---------------------------------------------                                     
 File: /home/mdr/proj/oss/re-frame/examples/todomvc/src/todomvc/core.cljs:39:53
--------------------------------------------------------------------------------
  36 | (defonce history
  37 |   (doto (History.)
  38 |     (events/listen EventType.NAVIGATE
  39 |                    (fn [event] (secretary/dispatch! (.-token event))))
-----------------------------------------------------------^--------------------
 Cannot infer target type in expression (. event -token)
--------------------------------------------------------------------------------                                     
  40 |     (.setEnabled true)))
  41 | 
  42 | 
  43 | ;; -- Entry Point -------------------------------------------------------------
--------------------------------------------------------------------------------
```

Of course it's not a biggie, it won't prevent me (or anybody else) from exploring re-frame, but I believe it's good to keep the onboarding experience frictionless.

I didn't understand the warning message, but a quick search pointed me to externs and type hints: 
https://clojurescript.org/guides/externs
https://gist.github.com/swannodette/4fc9ccc13f62c66456daf19c47692799

I know next to nothing about externs and type hints in ClojureScript, but it
seems that annotating `event` in `fn` on line 39 with the type below fixes
the warning.
https://google.github.io/closure-library/api/goog.History.Event.html


