### PR TITLE
Wrong param name in protocol's function (router.cljc)

### DIFF
--- a/src/re_frame/router.cljc
+++ b/src/re_frame/router.cljc
@@ -73,7 +73,7 @@
   ;; -- API
   (push [this event])
   (add-post-event-callback [this id callack])
-  (remove-post-event-callback [this f])
+  (remove-post-event-callback [this id])
   (purge [this])
 
   ;; -- Implementation via a Finite State Machine


### PR DESCRIPTION
Wrong param name in protocol's function.