### PR TITLE
Add support for multithreading dynamic appdb

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectCodeStyleSettingsManager">
-    <option name="PER_PROJECT_SETTINGS">
-      <value>
-        <ClojureCodeStyleSettings>{
-  :cljs.core/with-redefs 1
-  :cursive.formatting/align-binding-forms true
-  :cursive.formatting/comment-align-column 0
-  :re-frame.trace/register-trace-cb :only-indent
-  :re-frame.trace/with-trace 1
-}</ClojureCodeStyleSettings>
-        <XML>
-          <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
-        </XML>
-      </value>
-    </option>
-    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default (2)" />
-  </component>
+    <component name="ProjectCodeStyleSettingsManager">
+        <option name="PER_PROJECT_SETTINGS">
+            <value>
+                <ClojureCodeStyleSettings>{
+                    :cljs.core/with-redefs 1
+                    :cursive.formatting/align-binding-forms true
+                    :cursive.formatting/comment-align-column 0
+                    :re-frame.trace/register-trace-cb :only-indent
+                    :re-frame.trace/with-trace 1
+                    }</ClojureCodeStyleSettings>
+                <XML>
+                    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+                </XML>
+            </value>
+        </option>
+        <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+        <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default (2)" />
+    </component>
 </project>

--- a/src/re_frame/core.cljc
+++ b/src/re_frame/core.cljc
@@ -987,7 +987,7 @@
   []
   (let [handlers @registrar/kind->id->handler
         app-db   @db/app-db
-        subs-cache @subs/query->reaction]
+				subs-cache @subs/query->reaction]
     (fn []
       ;; call `dispose!` on all current subscriptions which
       ;; didn't originally exist.

--- a/src/re_frame/db.cljc
+++ b/src/re_frame/db.cljc
@@ -1,11 +1,39 @@
 (ns re-frame.db
-  (:require [re-frame.interop :refer [ratom]]))
+  (:require [re-frame.interop :refer [ratom]])
+  #?(:clj (:import [clojure.lang IAtom IDeref])))
 
+#?(:cljs (def app-db (ratom {})))
+#?(:clj
+    (do
+      (def ^:dynamic app-db-id nil)
+      (defonce db-atoms* (atom {}))
+      (defn db-id [] app-db-id)
 
-;; -- Application State  --------------------------------------------------------------------------
-;;
-;; Should not be accessed directly by application code.
-;; Read access goes through subscriptions.
-;; Updates via event handlers.
-(def app-db (ratom {}))
+      (defn swap-helper [a db-atoms* f & args]
+        (let [old-val (deref a)
+              new-val (apply f old-val args)]
+          (swap! db-atoms* assoc (db-id) new-val)
+          new-val))
 
+      (deftype ThreadLocalAtom []
+        IAtom
+        (swap [this f] (swap-helper this db-atoms* f))
+        (swap [this f x] (swap-helper this db-atoms* f x))
+        (swap [this f & args] (apply swap-helper this db-atoms* f args))
+
+        (compareAndSet [this old-val new-val]
+          (swap! db-atoms* assoc (db-id) new-val)
+          new-val)
+
+        (reset [this new-val]
+          (swap! db-atoms* assoc (db-id) new-val)
+          new-val)
+
+        IDeref
+        (deref [this]
+          (get @db-atoms* (db-id))))
+
+      (defn clear-app-db [id]
+        (swap! db-atoms* dissoc id))
+
+      (def app-db (->ThreadLocalAtom))))

--- a/src/re_frame/interop.clj
+++ b/src/re_frame/interop.clj
@@ -23,7 +23,7 @@
 (defn on-load
   [listener]) ;; no-op
 
-(defonce ^:private executor (Executors/newSingleThreadExecutor))
+(defonce ^:private executor (Executors/newCachedThreadPool))
 
 (defonce ^:private on-dispose-callbacks (atom {}))
 


### PR DESCRIPTION
This commit implements the idea explored by Techascent in [this blogpost](https://techascent.com/blog/isomorphic-rendering.html).

It accomplishes it by changing appdb to be a dynamic variable.
Then, when needed, one could serve an html with this snippet:
```clojure
(defn- handle-route*
 [app-db]
 (let [db-id (util/uuid)
       result (with-bindings {#'re-frame.db/app-db-id db-id}
                (swap! rf.db/db-atoms* assoc db-id app-db)
                (gen-html app-db))]
   (re-frame.db/clear-app-db db-id)
   result))
```

It makes sure that the cljs behavior is unchanged and only adds clj support.