### PR TITLE
Use fx vectors in reg-event-fx in docs

### DIFF
--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -212,7 +212,7 @@ was being changed).
 (def debug? ^boolean goog.DEBUG)
 (def standard-interceptors-fx
   [(when debug?  debug)    ;; as before
-   (when debug? (after #(if % (db/valid-schema? %)))]) ;; <-- different after
+   (when debug? (after #(if % (db/valid-schema? %))))]) ;; <-- different after
 ```
 and then:
 ```clj

--- a/docs/EffectfulHandlers.md
+++ b/docs/EffectfulHandlers.md
@@ -228,7 +228,7 @@ Here it is re-written so as to be pure:
    :my-event
    (fn [{:keys [db]} [_ a]]                ;; <2>
       {:db  (assoc db :flag true)          ;; <3>
-       :dispatch [:do-something-else 3]}))
+       :fx [[:dispatch [:do-something-else 3]]]}))
 ```
 
 Notes: <br>
@@ -239,7 +239,7 @@ it is a map which contains a `:db` key. <br>
 *<3>* The handler is returning a data structure (map) which describes two side-effects:
 
   - a change to application state, via the `:db` key
-  - a further event, via the `:dispatch` key
+  - a further event, via the `:fx` key calling the `:dispatch` effect handler
 
 Above, the impure handler **did** a `dispatch` side-effect, while the pure handler **described**
 a `dispatch` side-effect.
@@ -263,10 +263,10 @@ the pure, descriptive alternative:
 (reg-event-fx
    :my-event
    (fn [{:keys [db]} [_ a]]
-       {:http {:method :get
-               :url    "http://json.my-endpoint.com/blah"
-               :on-success  [:process-blah-response]
-               :on-fail     [:failed-blah]}
+       {:fx [[:http {:method :get
+                     :url    "http://json.my-endpoint.com/blah"
+                     :on-success  [:process-blah-response]
+                     :on-fail     [:failed-blah]}]]
         :db   (assoc db :flag true)}))
 ```
 
@@ -337,7 +337,7 @@ data from arguments.
 `-db` handlers take __one__ coeffect called `db`, and they return only __one__  effect (db again).
 
 Whereas `-fx` handlers take potentially __many__ coeffects (a map of them) and they return
-potentially __many__ effects (a map of them). So, One vs Many.
+potentially __many__ effects (a map of a vector of them). So, One vs Many.
 
 Just to be clear, the following two handlers achieve the same thing:
 ```clj

--- a/docs/FAQs/FocusOnElement.md
+++ b/docs/FAQs/FocusOnElement.md
@@ -59,7 +59,7 @@ You can then use this effect within your event handler:
   :something
   (fn [cofx event]
     {:db ....
-     :focus-to-element some-element-id}))
+     :fx [[:focus-to-element some-element-id]]}))
 ```
 
 This assumes you can compute or obtain the `some-element-id` value 

--- a/docs/Loading-Initial-Data.md
+++ b/docs/Loading-Initial-Data.md
@@ -90,10 +90,10 @@ values must be put in `app-db` via an event handler.
 Here's an event handler for that purpose:
 ```Clojure
 (re-frame.core/reg-event-db
-  :initialise-db				 ;; usage: (dispatch [:initialise-db])
-  (fn [_ _]						 ;; Ignore both params (db and event)
-	 {:display-name "DDATWD"	 ;; return a new value for app-db
-	  :items [1 2 3 4]}))
+  :initialise-db           ;; usage: (dispatch [:initialise-db])
+  (fn [_ _]                ;; Ignore both params (db and event)
+    {:display-name "DDATWD" ;; return a new value for app-db
+     :items [1 2 3 4]}))
 ```
 
 You'll notice that this handler does nothing other than to return a ` map`. That map 
@@ -130,13 +130,13 @@ quick sketch of the entire pattern. It is very straight-forward.
 (re-frame.core/reg-sub   ;; supplied main-panel with data
   :name                  ;; usage (subscribe [:name])
   (fn  [db _]
-	(:display-name db)))
-	   
+    (:display-name db)))
+
 (re-frame.core/reg-sub   ;; we can check if there is data
   :initialised?          ;; usage (subscribe [:initialised?])
   (fn  [db _]
-	(not (empty? db))))  ;; do we have data
-	
+    (not (empty? db))))  ;; do we have data
+
 (re-frame.core/reg-event-db
    :initialise-db
    (fn [db _]
@@ -145,7 +145,7 @@ quick sketch of the entire pattern. It is very straight-forward.
 (defn main-panel    ;; the top level of our app 
   []
   (let [name  (re-frame.core/subscribe [:name])]   ;; we need there to be good data
-    [:div "Hello " @name])))
+    [:div "Hello " @name]))
 
 (defn top-panel    ;; this is new
   []

--- a/docs/Solve-the-CPU-hog-problem.md
+++ b/docs/Solve-the-CPU-hog-problem.md
@@ -56,7 +56,7 @@ Here's an `-fx` handler which counts up to some number in chunks:
       ;; We are at the beginning, so:
       ;;     - modify db, causing popup of Modal saying "Working ..."
       ;;     - begin iterative dispatch. Give initial version of "so-far"
-      {:dispatch [:count-to false {:counter 0} finish-at]  ;; dispatch to self
+      {:fx [[:dispatch [:count-to false {:counter 0} finish-at]]]  ;; dispatch to self
        :db (assoc db :we-are-working true)}
       (if (> (:counter so-far) finish-at)
         ;; We are finished:
@@ -69,7 +69,7 @@ Here's an `-fx` handler which counts up to some number in chunks:
         ;;   - run the calculation
         ;;   - redispatch, passing in new running state
         (let [new-so-far   (update so-far :counter inc)]
-          {:dispatch [:count-to false new-so-far finish-at]}))))                         
+          {:fx [[:dispatch [:count-to false new-so-far finish-at]]]}))))
 ```
 
 ### Why Does A Redispatch Work?
@@ -171,8 +171,8 @@ about in the Wiki, and `re-dispatch` within an`-fx` handler:
   :process-x
   (fn 
     [{db :db} event-v]
-    {:dispatch  [:do-work-process-x]   ;; do processing later, give CPU back to browser.     
-     :db (assoc  db  :processing-X true)})) ;; so the modal gets rendered
+    {:fx [[:dispatch  [:do-work-process-x]]] ;; do processing later, give CPU back to browser.
+     :db (assoc  db  :processing-X true)}))  ;; so the modal gets rendered
 
 (re-frame.core/reg-event-db
   :do-work-process-x
@@ -202,7 +202,7 @@ To do this, you put metadata on the event being dispatched:
   :process-x
   (fn 
     [{db :db} event-v]
-    {:dispatch  ^:flush-dom [:do-work-process-x]   ;; <--- NOW WITH METADATA         
+    {:fx [[:dispatch  ^:flush-dom [:do-work-process-x]]]   ;; <--- NOW WITH METADATA
      :db (assoc  db  :processing-X true)}))  ;; so the modal gets rendered
 ```
 

--- a/docs/Talking-To-Servers.md
+++ b/docs/Talking-To-Servers.md
@@ -120,7 +120,7 @@ Here's our rewrite:
    (:require
       [ajax.core :as ajax]        
       [day8.re-frame.http-fx]  
-      [re-frame.core :refer [reg-event-fx]))
+      [re-frame.core :refer [reg-event-fx]]))
 
 (reg-event-fx        ;; <-- note the `-fx` extension
   :request-it        ;; <-- the event id
@@ -128,12 +128,13 @@ Here's our rewrite:
     [{db :db} _]     ;; <-- 1st argument is coeffect, from which we extract db 
    
     ;; we return a map of (side) effects
-    {:http-xhrio {:method          :get
-                  :uri             "http://json.my-endpoint.com/blah"
-                  :format          (ajax/json-request-format)
-                  :response-format (ajax/json-response-format {:keywords? true}) 
-                  :on-success      [:process-response]
-                  :on-failure      [:bad-response]}
+    {:fx [[:http-xhrio
+           {:method          :get
+            :uri             "http://json.my-endpoint.com/blah"
+            :format          (ajax/json-request-format)
+            :response-format (ajax/json-response-format {:keywords? true})
+            :on-success      [:process-response]
+            :on-failure      [:bad-response]}]]
      :db  (assoc db :loading? true)}))
 ```
 

--- a/docs/api-builtin-effects.md
+++ b/docs/api-builtin-effects.md
@@ -11,7 +11,7 @@ Event handlers, such as those registered using `reg-event-fx`, compute and retur
         [:full-screen true]
         [:http     {:method :GET  :url "http://somewhere.com/"}]]}
 ```
-That's a map with two keys:  `:db` and `:fx`.  Which means there are two effects in this example. In another case, there could be 
+That's a map with two keys:  `:db` and `:fx`.  Which means there are two effects in this example. In older code, there could be
 more or less.
 
 Each effect consists of an `id` and a `payload` pair. The `id` identifies the effect required and the `payload` 
@@ -80,7 +80,7 @@ usage:
 To dispatch multiple events:
 ```clojure
 {:fx [[:dispatch [:event1 "param1" :param2]]
-      [:dispatch [:second]]}
+      [:dispatch [:second]]]}
 ```
 Effects in `:fx` are actioned in order, so the dispatched events will be queued and, later handled, in order supplied. FIFO.
 
@@ -105,7 +105,7 @@ Removes a previously registered event handler. Expects the event id for a previo
 usage:
 ```clojure
 {:db new-db
- :fx [[:deregister-event-handler :my-id]])}
+ :fx [[:deregister-event-handler :my-id]]}
 ```
 
 


### PR DESCRIPTION
Given that the new recommended behavior is to use `:fx` in `reg-event-fx` return maps, it seems prudent to use this format in all of the documentation as well. I've done my best to cover all of the usages and update the language to correctly match the implementation.

I also fixed a couple mistakes around missing or extra parentheses and brackets in code blocks.