### PR TITLE
Allow enrich to return nil

### DIFF
--- a/src/re_frame/core.cljc
+++ b/src/re_frame/core.cljc
@@ -755,12 +755,14 @@
   "Returns an interceptor which will run the given function `f` in the `:after`
   position.
 
-  `f` is called with two arguments: `db` and `v`, and is expected to
+  `f` is called with two arguments: `db` and `event`, and is expected to
   return a modified `db`.
 
   Unlike the `after` interceptor which is only about side effects, `enrich`
   expects `f` to process and alter the given `db` coeffect in some useful way,
   contributing to the derived data, flowing vibe.
+
+  If `f` returns `nil`, the `db` value passed to `f` will be returned instead.
 
   #### Example Use:
 
@@ -795,7 +797,22 @@
   any CRUD operation.
 
   This brings huge simplicity at the expense of some re-computation
-  each time. This may be a very satisfactory trade-off in many cases."
+  each time. This may be a very satisfactory trade-off in many cases.
+
+  #### Returning nil
+
+  In some cases, it's useful to apply a change to specific situations that can
+  be determined at runtime instead of when defining the handler with an
+  `:enrich` interceptor. Instead of forcing you to return the `db` from every
+  non-applicable branch, you can return `nil` to use the given `db` value:
+
+      #!clj
+      (def set-last-update
+        (core/enrich
+          (fn [{db :db} [_ {user :user}]]
+            (when (active-user? user)  ;; <- Only perform an update if user is active
+              ...))))
+  "
   {:api-docs/heading "Interceptors"}
   [f]
   (std-interceptors/enrich f))

--- a/src/re_frame/std_interceptors.cljc
+++ b/src/re_frame/std_interceptors.cljc
@@ -198,12 +198,12 @@
     :id :enrich
     :after (fn enrich-after
              [context]
-             (let [event (get-coeffect context :event)
-                   db    (if (contains? (get-effect context) :db)
-                           (get-effect context :db) ;; If no db effect is returned, we provide the original coeffect.
-                           (get-coeffect context :db))]
-               (->> (f db event)
-                    (assoc-effect context :db))))))
+             (let [event   (get-coeffect context :event)
+                   prev-db (if (contains? (get-effect context) :db)
+                             (get-effect context :db) ;; If no db effect is returned, we provide the original coeffect.
+                             (get-coeffect context :db))
+                   new-db  (f prev-db event)]
+               (assoc-effect context :db (or new-db prev-db)))))) ;; If the enriched db is nil, use the last known good db
 
 
 


### PR DESCRIPTION
If the function `f` passed to `enrich` returns `nil`, use the value for `db` that was given to `f` instead of setting the `:db` effect on context to `nil`, which results in all changes to `db` being discarded.

I've updated the docs, added two tests, and fixed the existing test for `enrich` that was accidentally a no-op.

Closes #750