### PR TITLE
Warn user when calling subscribe outside of a reactive context

### DIFF
--- a/src/re_frame/interop.clj
+++ b/src/re_frame/interop.clj
@@ -91,3 +91,7 @@
   "Doesn't make sense in a Clojure context currently."
   [reactive-val]
   "rx-clj")
+
+(defn reactive?
+  []
+  true)

--- a/src/re_frame/interop.cljs
+++ b/src/re_frame/interop.cljs
@@ -72,3 +72,7 @@
            reagent.ratom/Track "tr"
            "other")
          (hash reactive-val))))
+
+(defn reactive?
+  []
+  (reagent.ratom/reactive?))


### PR DESCRIPTION
I saw the help wanted tag on issue #740 and decided to open a PR for it

This will log warnings to the console every time a call to subscribe is made in a place it shouldn't be called, like event handlers.

Here is what the warning looks like in firefox:
![image](https://user-images.githubusercontent.com/6585576/152726578-10d80444-f301-4357-9095-acc97bdaab77.png)

Right now it is printed as a warning. It may be more useful to print it as an error so the user can see the stack trace and find what code triggered the message.