### PR TITLE
throw error in unwrap interceptor instead of warning

### DIFF
--- a/src/re_frame/std_interceptors.cljc
+++ b/src/re_frame/std_interceptors.cljc
@@ -45,9 +45,9 @@
                (let [[_ payload :as event] (get-coeffect context :event)]
                  (if-not (and (= 2 (count event))
                               (map? payload))
-                   (do
-                     (console :warn "re-frame: \"unwrap\" interceptor requires event to be a 2-vector of [event-id payload-map]. Got " event)
-                     context)
+                   (throw (ex-info
+                            "re-frame: \"unwrap\" interceptor must be a vector of two elements \"[event-id payload-map]\""
+                            event))
                    (assoc-coeffect context :event payload))))
     :after   (fn unwrap-after
                [context]


### PR DESCRIPTION
**Motivation:**
When an event handler is registered using the `unwrap` standard interceptor, the interceptor expects the event to be dispatched as a two element vector where the second argument is a map. It currently checks for this and issues a console warning when this is not the case. However, this is a somewhat silent failure and the registered handler is still called with the original wrapped event vector. Depending on the handler's fn parameter definitions, this can cause destructuring error, or flow further downstream before an error in the dispatch is detected. In app which mixes both standard and unwrapped handlers (perhaps due to legacy code or third-party libs which don't yet support the `unwrap` contract, we want to detect an issue as soon as possible.

**Change:**
This PR modifies the `unwrap` handler to instead throw and error so that a disparity in the contract between the dispatcher and handler is identified as early as possible.
