### PR TITLE
Fix example reference in reg-sub docstring

### DIFF
--- a/src/re_frame/core.cljc
+++ b/src/re_frame/core.cljc
@@ -380,7 +380,7 @@
       (fn [a query-vec]       ;; 1st argument is a single value
          ...)
 
-  Further Note: variation #1 above, in which an `input-fn` was not supplied, like this:
+  Further Note: variation #1 above, in which an `signal-fn` was not supplied, like this:
 
       #!clj
       (reg-sub


### PR DESCRIPTION
Reading through the `reg-sub` docstring (https://day8.github.io/re-frame/api-re-frame.core/#reg-sub), I found confusing a reference to a function `input-fn` not previously mentioned in the document. From context, I understood it referred to the signal function used as the second argument of `reg-sub`.