### PR TITLE
warn-when-not-reactive: funcall vs. component use

### DIFF
--- a/docs/releases/2022.md
+++ b/docs/releases/2022.md
@@ -10,6 +10,10 @@
 
 > Committed but unreleased changes are put here, at the top. Older releases are detailed chronologically below.
 
+#### Changed
+
+- warn-when-not-reactive mentions another likely reason: `(subscribing-component)` instead of `[subscribing-component]`
+
 #### Breaking 
 
   - [763](https://github.com/day8/re-frame/pull/763) on detecting an incorrect event structure, the `unwrap` interceptor now exceptions instead of writing an error to `js/console` and continuing

--- a/src/re_frame/subs.cljc
+++ b/src/re_frame/subs.cljc
@@ -68,6 +68,7 @@
   (when (and debug-enabled? (not (reactive?)))
     (console :warn
              "re-frame: Subscribe was called outside of a reactive context.\n"
+             "Did you mean `[subscribing-component]` but wrote `(subscribing-component)`?\n"
              "See: https://day8.github.io/re-frame/FAQs/UseASubscriptionInAJsEvent/\n"
              "https://day8.github.io/re-frame/FAQs/UseASubscriptionInAnEventHandler/")))
 


### PR DESCRIPTION
Sometimes when I write hiccup, I write (component) instead of [component] which leads to the error message from #752 if component tries to subscribe to something.

The warning as it is now talks about subscribing from event handlers or from javascript events. I found this confusing because I was pretty certain I had not touched any event handlers.  But it also said "not in a reactive context" which got me on the right track.

I would argue that this is an even more likely cause for that warning and should be mentionend, especially since this is the more likely error for people new to reagent and/or re-frame.  There was no other output besides this warning, just a silently malfunctioning program.

I do not care about the exact wording, but I think there should be mention of function calls vs use of a component.

I am aware of #754 and that it wants to remove the warning again.  I would argue that instead of the new `(when (reactive?))` there should be an `if` where the else branch mentions function calls vs components.  I am pretty certain it does not fix this case - it just moves the check for `reactive?` into the function that is called from the old check location.
