### PR TITLE
Moves the calls to `warn-when-not-reactive` to the functions users are directly calling.

### DIFF
--- a/src/re_frame/core.cljc
+++ b/src/re_frame/core.cljc
@@ -496,8 +496,10 @@
   "
   {:api-docs/heading "Subscriptions"}
   ([query]
+   (subs/warn-when-not-reactive)
    (subs/subscribe query))
   ([query dynv]
+   (subs/warn-when-not-reactive)
    (subs/subscribe query dynv)))
 
 (defn clear-sub ;; think unreg-sub

--- a/src/re_frame/subs.cljc
+++ b/src/re_frame/subs.cljc
@@ -72,7 +72,6 @@
 
 (defn subscribe
   ([query]
-   (warn-when-not-reactive)
    (trace/with-trace {:operation (first-in-vector query)
                       :op-type   :sub/create
                       :tags      {:query-v query}}
@@ -91,7 +90,6 @@
            (cache-and-return query [] (handler-fn app-db query)))))))
 
   ([query dynv]
-   (warn-when-not-reactive)
    (trace/with-trace {:operation (first-in-vector query)
                       :op-type   :sub/create
                       :tags      {:query-v query


### PR DESCRIPTION
The goal of the change is to help users getting rid of false positive warnings, which in the browser console can hinder the discovery of other warnings that may happen during the normal development process of a re-frame app.