### PR TITLE
Properly eat flow effects in flows/do-fx

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,8 @@
 
   :profiles {:debug {:debug true}
              :dev   {:dependencies [[binaryage/devtools "1.0.3"]
-                                    [tortue/spy "2.15.0"]]
+                                    ;[tortue/spy "2.15.0"]
+                                    ]
                      :plugins      [[com.github.liquidz/antq "RELEASE"]
                                     [lein-shell              "0.5.0"]]
                      :antq         {}}

--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,8 @@
   :git-inject {:version-pattern #"v(\d+\.\d+\.\d+.*)"}
 
   :profiles {:debug {:debug true}
-             :dev   {:dependencies [[binaryage/devtools "1.0.3"]]
+             :dev   {:dependencies [[binaryage/devtools "1.0.3"]
+                                    [tortue/spy "2.15.0"]]
                      :plugins      [[com.github.liquidz/antq "RELEASE"]
                                     [lein-shell              "0.5.0"]]
                      :antq         {}}

--- a/src/re_frame/flow/alpha.cljc
+++ b/src/re_frame/flow/alpha.cljc
@@ -88,6 +88,8 @@
    (reg-flow (assoc m :id k)))
   ([m]
    (validate-inputs m)
+   #?(:cljs (js/console.log "existing flows:" (keys @flows)))
+   #?(:cljs (js/console.log "registering flow" (:id m)))
    (warn-stale-dependencies @flows m)
    (swap! flows assoc
           (:id m) (with-meta (merge (default (:id m)) m)

--- a/src/re_frame/flow/alpha.cljc
+++ b/src/re_frame/flow/alpha.cljc
@@ -88,8 +88,6 @@
    (reg-flow (assoc m :id k)))
   ([m]
    (validate-inputs m)
-   #?(:cljs (js/console.log "existing flows:" (keys @flows)))
-   #?(:cljs (js/console.log "registering flow" (:id m)))
    (warn-stale-dependencies @flows m)
    (swap! flows assoc
           (:id m) (with-meta (merge (default (:id m)) m)

--- a/src/re_frame/flow/alpha.cljc
+++ b/src/re_frame/flow/alpha.cljc
@@ -113,7 +113,7 @@
 
 (defn do-effect [[k v]] ((get-handler :fx k false) v))
 
-(def remove-fx (partial remove flow-fx-ids))
+(def remove-fx (partial remove (comp flow-fx-ids first)))
 
 (def do-fx
   (->interceptor

--- a/test/re_frame/flow/alpha_test.cljc
+++ b/test/re_frame/flow/alpha_test.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.flow.alpha-test
   (:require
    [cljs.test :refer [is deftest use-fixtures testing]]
-   [spy.core :as spy]
+   ;[spy.core :as spy]
    [re-frame.alpha :as rf]
    [re-frame.flow.alpha :as f]
    [re-frame.db :refer [app-db]]))
@@ -147,7 +147,9 @@
                  :path [:y]
                  :output #(swap! ct inc)}]
     (testing "registering just once with :reg-flow fx"
-      (with-redefs [f/reg-flow (spy/spy f/reg-flow)]
+      (with-redefs [
+                    ;f/reg-flow (spy/spy f/reg-flow)
+                    ]
         (rf/reg-event-fx :init (fn [_ _] {:db {:x 0} :fx [[:reg-flow ct-flow]]}))
         (rf/dispatch-sync [:init])
         (is (= 1 @ct))


### PR DESCRIPTION
This is my attempt at solving #815. I tried to reproduce the issue in a test but I couldn't get the test to fail; instead, I output messages to the console where you can observe they are printed twice instead of once -- on the ~second~ first commit of the feature branch.