### PR TITLE
Update interceptor history

### DIFF
--- a/docs/Interceptors.md
+++ b/docs/Interceptors.md
@@ -238,8 +238,10 @@ __path__ adds a `:comment` describing _which_ path it goes to.
 > All truths are easy to understand once they are discovered <br>
 >   -- Galileo Galilei
 
-This elegant and flexible arrangement was originally
-designed by the [Pedestal Team](https://github.com/pedestal/pedestal/blob/master/guides/documentation/service-interceptors.md). Thanks!
+This elegant and flexible arrangement was
+adapted for Clojure by the [Pedestal Team](https://github.com/pedestal/pedestal/blob/master/guides/documentation/service-interceptors.md). Thanks!
+
+Pre-Clojure work on interceptors can be found in [Tomcat's interceptors](https://tomcatbook.sourceforge.net/book/defaulthtml/ch04.html), Netty's ChannelPipeline handlers, and the [J2EE InterceptingFilter pattern](https://tomcatbook.sourceforge.net/book/defaulthtml/ch04.html) from _Pattern-Oriented Software Architecture, 2nd ed_.
 
 ## Let's Write An Interceptor
 


### PR DESCRIPTION
The Credit section seemed to say Pedestal created interceptors (that's how I interpret "originally designed" anyway), but they're older than Clojure. 

Both Netty and Tomcat used them at least as far back as the early 00's, and the pattern was documented in at least one book.

I wrote about it a bit more at length in https://clojurians.slack.com/archives/CDG3YQV6Z/p1685076301109489