### PR TITLE
[alpha] fix argument to legacy sub signal fn

### DIFF
--- a/src/re_frame/subs/alpha.cljc
+++ b/src/re_frame/subs/alpha.cljc
@@ -57,18 +57,18 @@
      :sub
      id
      (fn subs-handler-fn [_ q]
-       (let [subscriptions (inputs-fn q nil)
+       (let [q (if (map? q)
+                 (-> (or (::rf/query-v q) [(q/id q)])
+                     (vary-meta assoc ::rf/lifecycle (q/lifecycle q)))
+                 q)
+             subscriptions (inputs-fn q nil)
              rid (atom nil)
              r (make-reaction
                 #(trace/with-trace {:operation (q/id q)
                                     :op-type   :sub/run
                                     :tags      {:query      q
                                                 :reaction   @rid}}
-                   (let [q (if (map? q)
-                             (-> (or (::rf/query-v q) [(q/id q)])
-                                 (vary-meta assoc ::rf/lifecycle (q/lifecycle q)))
-                             q)
-                         subscription (computation-fn
+                   (let [subscription (computation-fn
                                        (deref-input-signals subscriptions id)
                                        q)]
                      (trace/merge-trace! {:tags {:value subscription}})


### PR DESCRIPTION
As described in #821, give the query vector to the input signal function instead of the new query map when using a legacy sub.

Note: this also reverts the trace data, `[:tags :query]` will be the query vector. I'm not sure whether we want this or not.