### PR TITLE
Deploy docs via Pages artifact instead of gh-pages branch

### DIFF
--- a/.github/workflows/docs-workflow.yml
+++ b/.github/workflows/docs-workflow.yml
@@ -4,11 +4,24 @@
 #
 # More about the build process are documented at
 # https://github.com/day8/re-frame/blob/feature/mkdocs/docs/developer-notes.md
+#
+# PREREQUISITE: the repository's Pages source must be set to "GitHub Actions"
+# (Settings -> Pages -> Build and deployment -> Source). If it is still set
+# to "Deploy from a branch" then the deploy-pages step in the github-pages
+# job below will fail and https://day8.github.io/re-frame/ will continue to
+# serve the last commit on the (now-unused) gh-pages branch until the
+# setting is corrected.
 
 name: docs
 on:
   push:
     branches: 'master'
+
+# Allow only one concurrent deployment, but do not cancel in-progress runs
+# so that an in-flight Pages deployment can complete before the next starts.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
   re-frame-docs-app:
@@ -103,34 +116,26 @@ jobs:
     name: GitHub Pages
     needs: mkdocs
     runs-on: ubuntu-24.04
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Checkout GitHub Pages Branch
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          ref: "gh-pages"
-          path: "gh-pages"
-
       - name: Download MkDocs Artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mkdocs
 
       - name: Extract MkDocs Artifact
-        run: |
-          tar zxf mkdocs.tar.gz
-          rm -rf gh-pages/*
-          cp -Rv site/* gh-pages/
+        run: tar zxf mkdocs.tar.gz
 
-      - name: Commit
-        working-directory: ./gh-pages
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add -A
-          git commit -m "Update docs"
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        with:
+          path: site/
 
-      - name: Push
-        working-directory: ./gh-pages
-        run: |
-          REMOTE="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push "${REMOTE}" HEAD:gh-pages
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
 ## Summary

  Closes #831.

  The current docs workflow commits the entire built MkDocs site to the
  `gh-pages` branch on every push to master. Over time this has accumulated
  ~100 MB of generated artifacts in `gh-pages` (`js/docs.js` at 1.8 MB ×
  626 versions, `klipse_plugin.js` at 7.6 MB, `re-frame-docs-app.tar.xz`,
  etc.) — and every `git clone` has to download all of it.

  This PR switches the third job of `docs-workflow.yml` from "commit the
  built site to `gh-pages`" to the modern artifact-based
  `actions/deploy-pages` flow. The site is served directly from an
  ephemeral workflow artifact, nothing is committed to git, and the
  `gh-pages` branch is no longer needed.

  The first two jobs (`re-frame-docs-app`, `mkdocs`) are unchanged.

  ## Required follow-up steps (after this merges)

  1. **Settings → Pages**: change the source from "Deploy from a branch"
     (`gh-pages`) to **"GitHub Actions"**. This must happen before the new
     workflow runs successfully — otherwise the `deploy-pages` step will
     fail and the site will keep serving stale content from `gh-pages`.
  2. After the first successful Actions-based deployment is verified at
     https://day8.github.io/re-frame/, delete the `gh-pages` branch:
     `git push origin --delete gh-pages`
  3. Wait 24–72h for GitHub's GC to repack the remote, after which a fresh
     clone should drop from ~100 MB to ~5 MB.

  ## Notes

  - The new actions are pinned to commit SHAs, matching the convention
    introduced in #830.
  - Job-level `permissions` are scoped only to the new `github-pages` job
    (`pages: write`, `id-token: write`) so the existing
    `re-frame-docs-app` and `mkdocs` jobs are not affected.
  - A top-level `concurrency: pages` block is added to prevent
    overlapping Pages deployments without cancelling in-flight runs.
  - The workflow file now carries a `PREREQUISITE` header comment so
    future maintainers reading the diff understand the Pages source must
    be set to "GitHub Actions".

  ## Test plan

  - [ ] Repository owner changes Pages source to "GitHub Actions"
  - [ ] Workflow runs successfully on merge to master
  - [ ] https://day8.github.io/re-frame/ loads correctly
  - [ ] Navigation, search, and the ClojureScript docs app render
  - [ ] `gh-pages` branch deleted; clone size verified to drop after GC