### PR TITLE
Fix unreachable code warning in validate-inputs

### DIFF
--- a/src/re_frame/flow/alpha.cljc
+++ b/src/re_frame/flow/alpha.cljc
@@ -60,8 +60,9 @@
              flows))
 
 (defn validate-inputs [{:keys [inputs]}]
-  (doseq [[_ input] inputs
-          :when (not ((some-fn db-path? flow<-?) input))]
+  (when (some (fn [[_ input]]
+                (not ((some-fn db-path? flow<-?) input)))
+              inputs)
     (throw (#?(:clj Exception. :cljs js/Error.) "bad input"))))
 
 (defn warn-stale-dependencies [flows new-flow]


### PR DESCRIPTION
The doseq macro expands into a loop with recur, so a throw in the body makes the continuation unreachable. Replace with some + throw to avoid the Closure Compiler advanced-compilation warning.

Fixes #827