### PR TITLE
To facilitate re-frame-pair

### DIFF
--- a/.github/workflows/continuous-deployment-workflow.yml
+++ b/.github/workflows/continuous-deployment-workflow.yml
@@ -67,7 +67,11 @@ jobs:
           npm install
           npm run release
 
-      - run: bb test :chrome-path '"${{ steps.setup-chrome.outputs.chrome-path }}"'
+      - name: Test (JVM — CLJ test namespaces)
+        run: bb test-jvm
+
+      - name: Test (CLJS — browser target via Chrome)
+        run: bb test :chrome-path '"${{ steps.setup-chrome.outputs.chrome-path }}"'
 
       - name: Slack notification
         uses: homoluctus/slatify@61c6b12d2ae226db04062ff9b43d9679e2d53236 # v2.0.1

--- a/.github/workflows/docs-workflow.yml
+++ b/.github/workflows/docs-workflow.yml
@@ -66,6 +66,7 @@ jobs:
         run: |
           mv api-re-frame.alpha.md js
           mv api-re-frame.core.md js
+          mv api-re-frame.macros.md js
           tar Jcf re-frame-docs-app.tar.xz js
 
       - name: Upload re-frame-docs App Artifact
@@ -99,6 +100,7 @@ jobs:
           tar Jxf re-frame-docs-app.tar.xz
           mv js/api-re-frame.alpha.md api-re-frame.alpha.md
           mv js/api-re-frame.core.md api-re-frame.core.md
+          mv js/api-re-frame.macros.md api-re-frame.macros.md
 
       - name: Build MkDocs Documentation
         run: mkdocs build

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ docs/**/*.pdf
 docs/**/*.mobi
 docs/api-re-frame.alpha.md
 docs/api-re-frame.core.md
+docs/api-re-frame.macros.md
 build/
 *~
 /package.json

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ build/
 .lsp
 .clj-kondo
 .*
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
-The [CHANGELOG has moved here](https://day8.github.io/re-frame/releases/2024).
+The [CHANGELOG has moved here](https://day8.github.io/re-frame/releases/2026).
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ In re-frame, events are causal, and views are purely reactive.
 
 The re-frame documentation is [available here](https://day8.github.io/re-frame/).
 
+### Programmatic Diagnostics (1.4.6+)
+
+The documentation includes a
+[Debugging & Instrumentation](https://day8.github.io/re-frame/Debugging/#programmatic-diagnostics)
+guide for devtools and diagnostic code: source-meta macros, trace tag
+schema validation, per-dispatch epoch callbacks, dry-run dispatch with
+effect overrides, and subscription cache lookups.
+
 ### Source-meta opt-in
 
 `re-frame.core` is the stable function API — `reg-event-db` /
@@ -78,4 +86,3 @@ For full dependency information, see the [Clojars page](https://clojars.org/re-f
 ## Licence
 
 re-frame is [MIT licenced](license.txt)
-

--- a/bb.edn
+++ b/bb.edn
@@ -5,7 +5,7 @@
  :tasks
  {:requires    ([day8.dev :as dev])
   test         (do (clojure "-M:test" "compile" "browser-test")
-                   (clojure "-X:test"))
+                   (apply clojure "-X:test" *command-line-args*))
   test-jvm     (clojure "-X:jvm-test")
   watch-test   (clojure "-M:test watch browser-test")
   watch-docs   (clojure "-M:docs" "watch" "docs")

--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -11,6 +11,64 @@ Event handlers are quite central to a re-frame app.  Only event handlers
 can update `app-db` to "step" an application "forward" from one state
 to the next.
 
+## Programmatic Diagnostics
+
+Most application debugging starts with the tools above, but devtools and
+diagnostic code often need stable data rather than formatted console output.
+
+`re-frame.macros` is an opt-in mirror of `re-frame.core` for callers that
+want source provenance. Alias it instead of `re-frame.core` in a dev build:
+
+```clj
+(ns my.app.events
+  (:require [re-frame.macros :as rf]))
+```
+
+The macro versions of `dispatch`, `dispatch-sync`, and `subscribe` attach
+call-site `{:file :line}` data as `:re-frame/source` metadata on event
+vectors and query vectors. The registration macros (`reg-event-db`,
+`reg-event-fx`, `reg-event-ctx`, `reg-sub`, and `reg-fx`) attach the same
+metadata to the registered handler. This answers questions like "why did
+this event fire?", "which view asked for this subscription?", and "where
+was this handler registered?" without relying on stack traces.
+
+Trace consumers should treat `re-frame.trace/tag-schema` as the contract for
+trace `:tags`. It lists the required and optional tags for each `:op-type`,
+including dispatch correlation tags like `:dispatch-id`,
+`:parent-dispatch-id`, the pre-interceptor `:event/original`, and
+subscription dependency tags such as `:input-query-vs`. Turn on
+`set-validate-trace!` in development or CI to warn when emitted traces drift
+from that schema.
+
+`register-trace-cb` receives raw trace batches. `register-epoch-cb` is the
+higher-level callback for tooling that wants one assembled record per event
+dispatch, with child traces grouped by dispatch lineage.
+
+For subscriptions, `live-query-vs` returns the current cache inventory: all
+currently-live query vectors. `query-v-for-reaction` is the reverse lookup
+for one reaction. Together they cover both directions of the
+cache-to-reaction relationship without making tools walk internal cache-key
+shapes.
+
+## Dry-Run Dispatch
+
+`dispatch-with` and `dispatch-sync-with` run an event with selected effect
+handlers replaced for that dispatch and its synchronous `:fx [:dispatch ...]`
+cascade. This is useful at the REPL and in tests when you want to exercise a
+real event graph while stubbing effects such as `:http-xhrio`, navigation, or
+local storage:
+
+```clj
+(re-frame.core/dispatch-with
+  [:user/save {:id 42}]
+  {:http-xhrio (fn [request]
+                 (js/console.log "stubbed request" request))})
+```
+
+The override map is carried on event metadata under `:re-frame/fx-overrides`
+and is consumed by re-frame's effect dispatch machinery. Normal app code does
+not need to read that metadata directly.
+
 
 ## The `debug` Interceptor
 

--- a/docs/api-intro.md
+++ b/docs/api-intro.md
@@ -29,9 +29,14 @@ You'll then be able to use the functions in the API, perhaps like this: `rf/disp
 
 ## The Most Commonly Used Part Of The API
 
-When you are writing `View Functions`: 
+When you are dispatching events:
 
   - `dispatch` (or occasionally, `dispatch-sync`)
+  - `dispatch-with` / `dispatch-sync-with` when you want selected effect handlers stubbed for one dispatch
+  - `dispatch-and-settle` when tests or diagnostics need to wait for a dispatch cascade to finish
+
+When you are writing `View Functions`: 
+
   - `subscribe`
 
 When you are registering:
@@ -58,6 +63,40 @@ Global interceptors can be very useful:
 When errors arise:
 
   - Catch them from events and interceptors via `reg-event-error-handler`
+
+## Diagnostics & Instrumentation
+
+Programmatic tooling can use these APIs without reaching into private
+implementation details:
+
+  - `version` reports the running re-frame artifact version.
+  - `live-query-vs` returns a snapshot of every currently-live subscription query vector.
+  - `query-v-for-reaction` returns the query vector that produced a known reaction.
+  - `register-trace-cb` and `remove-trace-cb` subscribe to the raw trace stream.
+  - `register-epoch-cb` and `remove-epoch-cb` subscribe to assembled per-dispatch epoch records.
+  - `tag-schema` documents the trace `:tags` contract for downstream tooling.
+  - `validate-trace?`, `set-validate-trace!`, and `check-trace-against-schema`
+    provide opt-in trace tag validation for development and CI.
+
+See [Debugging & Instrumentation](Debugging.md) and
+[re-frame.tooling](Tooling.md) for the longer-form story.
+
+## Source-meta Macros
+
+`re-frame.macros` is an opt-in macro mirror for diagnostics that need
+call-site `{:file :line}` metadata on dispatched events, subscription
+queries, or registered handlers:
+
+```clj
+(ns my-app.some-namespace
+  (:require [re-frame.macros :as rf]))
+```
+
+The macros have the same call shape as their `re-frame.core` counterparts
+(`dispatch`, `dispatch-sync`, `subscribe`, `reg-event-db`,
+`reg-event-fx`, `reg-event-ctx`, `reg-sub`, and `reg-fx`). In DEBUG builds
+they attach `:re-frame/source` metadata; in production CLJS builds the
+metadata path is removed by Closure dead-code elimination.
 
 ## More Rarely Used Part
 

--- a/docs/cljdoc.edn
+++ b/docs/cljdoc.edn
@@ -1,2 +1,6 @@
 {:cljdoc.doc/tree [["README" {:file "README.md"}]]
- :cljdoc.api/namespaces []}
+ :cljdoc.api/namespaces [re-frame.core
+                         re-frame.macros
+                         re-frame.trace
+                         re-frame.tooling
+                         re-frame.alpha]}

--- a/docs/releases/2026.md
+++ b/docs/releases/2026.md
@@ -8,12 +8,211 @@
 
 ## Unreleased
 
+The theme of this body of work is **programmatic diagnostics**: a
+supported, value-position-safe surface for devtools (re-frame-10x,
+re-frame-pair, re-frame-debux, custom dashboards, AI agents) to
+introspect re-frame's runtime without grepping internal namespaces or
+walking cache structures whose shape isn't a public contract. See the
+[Debugging & Instrumentation](../Debugging.md) guide and the
+[`re-frame.tooling`](../Tooling.md) page for the longer-form story.
+
 #### Added
 
-- `re-frame.tooling` — discoverability namespace for tooling consumers (no source-of-truth moves; pure re-export).
-- `re-frame.macros/reg-event-db` / `reg-event-fx` / `reg-event-ctx` / `reg-sub` / `reg-fx` — opt-in macros that capture call-site `{:file :line}` and attach it as metadata on the registered handler (`(meta (re-frame.registrar/get-handler kind id))`). Migration is alias-only: swap `re-frame.core` for `re-frame.macros` in your `:require` to get source-meta.
+##### Discoverability
+
+- `re-frame.tooling` — discoverability namespace for tooling consumers.
+  Re-exports the supported surface (dispatch overrides, trace cb /
+  schema, live subscription cache, registrar atom) without renaming or
+  moving any symbol — source-of-truth definitions stay in their
+  original namespaces. Require ONE namespace to find the contract:
+
+        (require '[re-frame.tooling :as rft])
+        (rft/dispatch-with [:my-event] {:effect-id (fn [_] ...)})
+        (rft/register-trace-cb :my-tool (fn [traces] ...))
+        @rft/query->reaction               ;; live subscription cache
+        @rft/kind->id->handler             ;; registrar atom
+
+##### Source-meta opt-in (`re-frame.macros`)
+
+- `re-frame.macros/dispatch`, `dispatch-sync`, `subscribe`,
+  `reg-event-db`, `reg-event-fx`, `reg-event-ctx`, `reg-sub`, `reg-fx`
+  — drop-in macro replacements for the corresponding `re-frame.core`
+  functions that capture call-site `{:file :line}` at expansion time
+  and stamp it as `:re-frame/source` on the relevant value (event
+  vector, query vector, registered handler chain). Migration is
+  alias-only — swap `re-frame.core` for `re-frame.macros` in your
+  `:require`:
+
+        ;; function API — no source-meta
+        (:require [re-frame.core   :as rf])
+
+        ;; macro API — same call shape, source-meta captured
+        (:require [re-frame.macros :as rf])
+
+  Read back via `(:re-frame/source (meta event))` inside event
+  handlers, `(meta (re-frame.registrar/get-handler kind id))` for
+  registered handlers, or `(re-frame.core/query-v-for-reaction r)` for
+  the meta'd query-v of a subscription. Cache identity is unaffected
+  (vector / map equality ignores metadata). In CLJS production builds
+  (`goog.DEBUG=false`) the meta-attach branch is eliminated by Closure
+  dead-code elimination, so the macro reduces to a bare
+  `re-frame.core/...` call with zero allocation overhead. Macros
+  cannot be used in value position; for `(apply reg-sub ...)`,
+  `(map reg-event-db ...)`, `(partial reg-fx ...)` keep using
+  `re-frame.core`.
+
+##### Dispatching events
+
+- `re-frame.core/dispatch-with`, `dispatch-sync-with` — fire `event`
+  with selected fx handlers temporarily substituted for the duration
+  of the dispatch and any synchronous `:fx [:dispatch ...]` cascade.
+  Stubs ride on event metadata, not global state, so no try/finally
+  is needed and overlapping calls don't interfere. Useful for dry-run
+  dispatches in dev (observe `:effects` / `app-db` change while
+  stubbing `:http-xhrio` / navigation), dispatch-scoped test stubs,
+  and reversible REPL exploration.
+
+        (re-frame.core/dispatch-with
+          [:user/login {:email "..." :password "..."}]
+          {:http-xhrio (fn [req]
+                         (re-frame.core/dispatch
+                           (conj (:on-success req) {:stubbed true})))})
+
+- `re-frame.core/dispatch-and-settle` — fire `event` and return a
+  deferred value that resolves once the event AND its synchronous
+  `:fx [:dispatch ...]` cascade have settled. Resolves to
+  `{:ok? true :root-epoch <id> :cascaded-epochs [<id> ...]}` on
+  success or `{:ok? false :reason :timeout :event ev :captured-epochs
+  [...]}` on timeout. CLJS returns a JS Promise; CLJ returns a
+  `clojure.core/promise`. Accepts an `opts` map:
+  `:timeout-ms` (default 5000), `:settle-window-ms` (default 100),
+  `:include-cascaded?` (default true), and `:overrides` — an
+  fx-id → stub-fn map composed with `dispatch-with`'s contract and
+  propagated through the cascade. Useful for tests and diagnostics
+  that need to wait for a cascade to finish before asserting on the
+  resulting state.
+
+        ;; CLJS — await the promise
+        (-> (re-frame.core/dispatch-and-settle [:cart/checkout])
+            (.then (fn [result] ...)))
+
+        ;; Override selected fx while awaiting the cascade
+        @(re-frame.core/dispatch-and-settle
+           [:cart/checkout]
+           {:overrides {:http-xhrio stub-success}})
+
+##### Subscription accessors
+
+- `re-frame.core/live-query-vs`, `re-frame.core/query-v-for-reaction`
+  — public, cache-shape-stable accessors for devtools that
+  previously had to fake them by walking internal `query->reaction`
+  keys.
+  - `live-query-vs` returns a snapshot sequence of every currently-
+    live cached query vector. Useful as a sub-cache-size probe:
+    `(count (re-frame.core/live-query-vs))`.
+  - `query-v-for-reaction` is the inverse of `subscribe`: given a
+    reaction held by tooling, return the query-v that produced it
+    (or nil if unknown / disposed). Backed by an object-identity-
+    keyed reverse map maintained alongside the subscription cache;
+    entries clear when the reaction is disposed. The reverse-map
+    insert is gated on `is-trace-enabled?` so it costs nothing in
+    production builds without tracing.
+
+  Both are also re-exported from `re-frame.alpha` (hidden from
+  api-docs) and `re-frame.tooling`.
+
+##### Tracing
+
+- `re-frame.core/tag-schema` — schema describing `:tags` for every
+  op-type re-frame emits (`:event`, `:event/handler`, `:event/do-fx`,
+  `:sub/create`, `:sub/run`, `:sub/dispose`, `:render`, `:raf`,
+  `:raf-end`, `:reagent/quiescent`, `:sync`). Each entry lists
+  `:required` keys, `:optional` keys, and a one-line `:doc`. Doc-only
+  by default; downstream tooling reads it as a load-bearing contract
+  for the trace stream. Adding a key is additive; renaming or
+  removing a key is breaking and must go through a deprecation
+  cycle.
+
+- `re-frame.core/validate-trace?`, `set-validate-trace!` — opt-in
+  runtime trace tag validation. With validation on, `finish-trace`
+  checks `:tags` against `tag-schema` and warns via `console :warn`
+  on missing required keys or unknown keys. Off by default; intended
+  for dev / CI to catch schema drift in re-frame core and in
+  third-party trace emitters early.
+
+        (re-frame.core/set-validate-trace! true)
+
+- `re-frame.core/register-epoch-cb`, `remove-epoch-cb`,
+  `assemble-epochs` — assembled-epoch callback alongside
+  `register-trace-cb`. Where `register-trace-cb` delivers the raw
+  trace stream, `register-epoch-cb` delivers one assembled record
+  per `:event` trace, partitioning each batch into the dispatch /
+  handler / do-fx / sub-create / sub-run shape downstream tools
+  want. Each epoch carries its own `:dispatch-id` and
+  `:parent-dispatch-id`; consumers wanting a tree-shaped view of a
+  user-fired event plus its chained children build it post-delivery
+  by walking parent-id pointers. Same gating as `register-trace-cb`
+  (opt-in via `:closure-defines` `re_frame.trace.trace_enabled_QMARK_
+  true`) and same delivery boundary (debounced batches on CLJS,
+  synchronous on CLJ at the outermost trace's finish). The cascade-
+  settled signal that some consumers want lives separately under
+  `dispatch-and-settle` — keeping the two decoupled lets
+  `register-epoch-cb` ship without depending on async-settle
+  infrastructure.
+
+- New trace tag keys (additive — see `tag-schema`):
+  - `:event/original` on `:event` traces — the dispatched event
+    vector pinned at `re-frame.events/handle` entry, before any
+    interceptor rewrites `:event`. Always present on re-frame
+    core's `:event` traces; downstream tools can rely on it for
+    "the user dispatched THIS" reporting even when an interceptor
+    has trimmed / wrapped / unwrapped the event the handler sees.
+  - `:dispatch-id` and `:parent-dispatch-id` on `:event`,
+    `:event/handler`, `:event/do-fx` traces — auto-generated UUIDs
+    threaded through the cascade. User-fired top-level dispatches
+    have `:parent-dispatch-id nil`; events queued via
+    `:fx [:dispatch ...]` carry the originator's `:dispatch-id` as
+    their `:parent-dispatch-id`. Lets tooling stitch a cascade tree
+    out of a flat trace stream without inferring parent-of from
+    timing.
+  - `:input-query-vs` on `:sub/run` traces — the query-vs of input
+    signals (alongside the existing `:input-signals` reagent-ids).
+    Lets tooling identify input subs by query-v rather than by the
+    Reagent-internal id.
+
+##### Diagnostics
+
+- `re-frame.core/version` — runtime-readable string identifying the
+  deployed re-frame artifact. Useful for devtools, instrumentation,
+  and version-floor probes (e.g. re-frame-pair's
+  `read-version-of`) that need to know which re-frame they're
+  running against without parsing `pom.xml` at runtime.
+  Re-exported from `re-frame.config/version`; mirrored as
+  `re-frame.alpha/version`.
+
+- `re-frame.config` — new namespace exposing `version`. Under CLJS
+  this is a `goog-define`; apps embedding re-frame can override at
+  build time via shadow-cljs `:closure-defines` to bake the resolved
+  git-tag version into release artifacts:
+
+        :closure-defines {re-frame.config/version :day8.dev/git-app-version}
+
+  Modeled on `re-com.config/version` so version-probe code can read
+  both libraries with the same global-path lookup
+  (`goog.global.<lib>.config.version`).
 
 #### Changed
+
+- `re-frame.registrar/register-handler` now logs a console warning
+  on duplicate handler registrations in production builds
+  (`goog.DEBUG=false`) or before re-frame's hot-reload `loaded?`
+  gate is set. Hot-reload from figwheel / shadow-cljs after page
+  load remains silent (the same gate already used elsewhere). In
+  production a duplicate `reg-event-db` / `reg-sub` / `reg-fx` for
+  the same id almost always indicates a bug — typo, copy-paste,
+  ns load order — so the warning surfaces it loudly. Apps relying
+  on silent overwrite (rare, almost certainly bug-shaped) should
+  investigate.
 
 - Reverted the defmacro conversion of `reg-event-db` / `reg-event-fx` / `reg-event-ctx` / `reg-sub` / `reg-fx` in `re-frame.core` (and the `re-frame.alpha` mirrors) — they are functions again, restoring `(apply reg-event-db ...)`, `(map reg-sub ...)`, `(partial reg-fx ...)` and other higher-order use. Source-meta capture moved to the opt-in `re-frame.macros` namespace (alias-swap migration). The `*-fn` companion fns added during the macro experiment (`reg-event-db-fn`, etc.) are removed.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,7 +72,7 @@ nav:
       - Loading Initial Data: Loading-Initial-Data.md
       - Talking To Servers: Talking-To-Servers.md
       - Subscribing to External Data: Subscribing-To-External-Data.md
-      - Debugging.md
+      - Debugging & Instrumentation: Debugging.md
       - Testing.md
       - Eek! Performance Problems: Performance-Problems.md
       - Solve the CPU hog problem: Solve-the-CPU-hog-problem.md
@@ -103,6 +103,7 @@ nav:
     - Overview: api-intro.md
     - Builtin Effects: api-builtin-effects.md
     - re-frame.core: api-re-frame.core.md
+    - re-frame.macros: api-re-frame.macros.md
     - re-frame.alpha: api-re-frame.alpha.md
   - Tooling:
     - re-frame.tooling: Tooling.md

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -21,4 +21,5 @@
            :target     :browser
            :build-hooks
            [(ns-to-markdown/hook {"src/re_frame/core.cljc"  "docs/api-re-frame.core.md"
+                                  "src/re_frame/macros.cljc" "docs/api-re-frame.macros.md"
                                   "src/re_frame/alpha.cljc" "docs/api-re-frame.alpha.md"})]}}}

--- a/src/re_frame/core.cljc
+++ b/src/re_frame/core.cljc
@@ -177,10 +177,11 @@
          (.then (fn [result] (...))))
 
      ;; CLJ — deref the promise (blocks until resolved)
-     @(dispatch-and-settle [:cart/checkout])
+     (deref (dispatch-and-settle [:cart/checkout]))
 
      ;; Override selected fx handlers while awaiting the cascade
-     @(dispatch-and-settle [:cart/checkout] {:overrides {:http-xhrio stub-success}})
+     (deref (dispatch-and-settle [:cart/checkout]
+                                  {:overrides {:http-xhrio stub-success}}))
 
    IMPLEMENTATION
 

--- a/src/re_frame/core.cljc
+++ b/src/re_frame/core.cljc
@@ -152,6 +152,8 @@
                              ;                settled
      :include-cascaded? bool ; default true — include child epochs
                              ;                fired via :fx [:dispatch ...]
+     :overrides         map  ; fx-id -> stub-fn, as in dispatch-with;
+                             ; inherited by the synchronous cascade
 
    USAGE
 
@@ -161,6 +163,9 @@
 
      ;; CLJ — deref the promise (blocks until resolved)
      @(dispatch-and-settle [:cart/checkout])
+
+     ;; Override selected fx handlers while awaiting the cascade
+     @(dispatch-and-settle [:cart/checkout] {:overrides {:http-xhrio stub-success}})
 
    IMPLEMENTATION
 

--- a/src/re_frame/core.cljc
+++ b/src/re_frame/core.cljc
@@ -51,6 +51,10 @@
 
       
       (dispatch [:order \"pizza\" {:supreme 2 :meatlovers 1 :veg 1}])
+
+  See also: `dispatch-with` for per-dispatch fx substitution,
+  `dispatch-and-settle` for awaiting a dispatch cascade, and
+  `re-frame.macros/dispatch` for DEBUG call-site source metadata.
   "
   {:api-docs/heading "Dispatching Events"}
   [event]
@@ -79,6 +83,10 @@
 
       
       (dispatch-sync [:sing :falsetto \"piano accordion\"])
+
+  See also: `dispatch-sync-with` for synchronous fx substitution,
+  and `re-frame.macros/dispatch-sync` for DEBUG call-site source
+  metadata.
   "
   {:api-docs/heading "Dispatching Events"}
   [event]
@@ -128,8 +136,13 @@
 (defn dispatch-sync-with
   "Like `dispatch-with`, but processes the event synchronously
    (matching the difference between `dispatch` and
-   `dispatch-sync`). See `dispatch-with` for the override
-   semantics + cascade behaviour."
+   `dispatch-sync`). Overrides apply to the event and any
+   `:fx [:dispatch ...]` cascade it starts.
+
+       (dispatch-sync-with [:user/login {:email \"...\"}]
+                           {:http-xhrio (fn [req] ...)})
+
+   See `dispatch-with` for the full override semantics."
   {:api-docs/heading "Dispatching Events"}
   [event overrides]
   (router/dispatch-sync (vary-meta event assoc :re-frame/fx-overrides overrides)))
@@ -222,6 +235,9 @@
           (-> db
             (dissoc arg1)
             (update :key + arg2))))   ;; return updated db
+
+  See also: `re-frame.macros/reg-event-db` for DEBUG call-site source
+  metadata on registered handlers.
   "
   {:api-docs/heading "Event Handlers"}
   ([id handler]
@@ -256,6 +272,9 @@
         (fn [{:keys [db] :as cofx} [_ arg1 arg2]] ;; destructure both arguments
           {:db (assoc db :some-key arg1)          ;; return a map of effects
            :fx [[:dispatch [:some-event arg2]]]}))
+
+  See also: `re-frame.macros/reg-event-fx` for DEBUG call-site source
+  metadata on registered handlers.
   "
   {:api-docs/heading "Event Handlers"}
   ([id handler]
@@ -287,6 +306,9 @@
                              function3)
                 effects  (select-keys result [:db :fx])]
              (assoc context :effects effects))))
+
+  See also: `re-frame.macros/reg-event-ctx` for DEBUG call-site source
+  metadata on registered handlers.
   "
   {:api-docs/heading "Event Handlers"}
   ([id handler]
@@ -556,7 +578,8 @@
   For further understanding, read the tutorials, and look at the detailed comments in
   /examples/todomvc/src/subs.cljs.
 
-  See also: `subscribe`
+  See also: `subscribe`, and `re-frame.macros/reg-sub` for DEBUG
+  call-site source metadata on registered subscription handlers.
   "
   {:api-docs/heading "Subscriptions"}
   [query-id & args]
@@ -620,7 +643,9 @@
   Two, or more, concurrent subscriptions for the same query will
   source reactive updates from the one executing handler.
 
-  See also: `reg-sub`
+  See also: `reg-sub`, `re-frame.macros/subscribe` for DEBUG
+  call-site source metadata, and `query-v-for-reaction` for recovering
+  the query vector from a held reaction.
   "
   {:api-docs/heading "Subscriptions"}
   ([query]
@@ -718,6 +743,9 @@
 
   then the `handler` `fn` we registered previously, using `reg-fx`, will be
   called with an argument of `[1 2]`.
+
+  See also: `re-frame.macros/reg-fx` for DEBUG call-site source
+  metadata on registered effect handlers.
   "
   {:api-docs/heading "Effect Handlers"}
   [id handler]

--- a/src/re_frame/core.cljc
+++ b/src/re_frame/core.cljc
@@ -144,6 +144,8 @@
      {:ok? false :reason :timeout :event ev :captured-epochs [...]}
 
    CLJS returns a JS Promise; CLJ returns a `clojure.core/promise`.
+   In both cases the resolved value is a Clojure map — CLJS callers
+   should NOT `js->clj` it.
 
    `opts` (all optional):
      :timeout-ms        int  ; default 5000 — overall budget

--- a/src/re_frame/core.cljc
+++ b/src/re_frame/core.cljc
@@ -30,6 +30,7 @@
                                                            fx-handler->interceptor
                                                            ctx-handler->interceptor]]
    [re-frame.flow.alpha       :as flow]
+   [re-frame.trace            :as trace]
    [re-frame.utils            :as utils]
    [clojure.set               :as set]))
 
@@ -1266,6 +1267,40 @@
   {:api-docs/heading "Logging"}
   [level & args]
   (apply loggers/console level args))
+
+;; -- tracing ----------------------------------------------------------------
+
+(def ^{:api-docs/heading "Tracing"} tag-schema
+  "Schema for `:tags` of every op-type re-frame emits."
+  trace/tag-schema)
+
+(def ^{:api-docs/heading "Tracing"} validate-trace?
+  "True iff runtime trace-tag validation is enabled."
+  trace/validate-trace?)
+
+(def ^{:api-docs/heading "Tracing"} set-validate-trace!
+  "Enable or disable runtime trace-tag validation."
+  trace/set-validate-trace!)
+
+(def ^{:api-docs/heading "Tracing"} register-trace-cb
+  "Register a callback that receives each batch of finished traces."
+  trace/register-trace-cb)
+
+(def ^{:api-docs/heading "Tracing"} remove-trace-cb
+  "Remove a trace callback by key."
+  trace/remove-trace-cb)
+
+(def ^{:api-docs/heading "Tracing"} register-epoch-cb
+  "Register a callback that receives assembled epoch records."
+  trace/register-epoch-cb)
+
+(def ^{:api-docs/heading "Tracing"} remove-epoch-cb
+  "Remove an epoch callback by key."
+  trace/remove-epoch-cb)
+
+(def ^{:api-docs/heading "Tracing"} assemble-epochs
+  "Partition a finished trace batch into event epoch records."
+  trace/assemble-epochs)
 
 ;; -- unit testing ------------------------------------------------------------
 

--- a/src/re_frame/core.cljc
+++ b/src/re_frame/core.cljc
@@ -179,6 +179,20 @@
 
 ;; -- Events ------------------------------------------------------------------
 
+;; The three `reg-event-XX` defns share a fixed interceptor chain and
+;; differ only in the trailing handler shape — db / fx / ctx. The
+;; chain lives in `-reg-event` and each public defn delegates with the
+;; matching `XX-handler->interceptor` constructor.
+
+(defn- -reg-event
+  [id interceptors handler->interceptor handler]
+  (events/register id [cofx/inject-db
+                       fx/do-fx
+                       flow/interceptor
+                       std-interceptors/inject-global-interceptors
+                       interceptors
+                       (handler->interceptor handler)]))
+
 (defn reg-event-db
   "Register the given event `handler` (function) for the given `id`. Optionally, provide
   an `interceptors` chain:
@@ -211,12 +225,7 @@
   ([id handler]
    (reg-event-db id nil handler))
   ([id interceptors handler]
-   (events/register id [cofx/inject-db
-                        fx/do-fx
-                        flow/interceptor
-                        std-interceptors/inject-global-interceptors
-                        interceptors
-                        (db-handler->interceptor handler)])))
+   (-reg-event id interceptors db-handler->interceptor handler)))
 
 (defn reg-event-fx
   "Register the given event `handler` (function) for the given `id`. Optionally, provide
@@ -250,12 +259,7 @@
   ([id handler]
    (reg-event-fx id nil handler))
   ([id interceptors handler]
-   (events/register id [cofx/inject-db
-                        fx/do-fx
-                        flow/interceptor
-                        std-interceptors/inject-global-interceptors
-                        interceptors
-                        (fx-handler->interceptor handler)])))
+   (-reg-event id interceptors fx-handler->interceptor handler)))
 
 (defn reg-event-ctx
   "Register the given event `handler` (function) for the given `id`. Optionally, provide
@@ -286,12 +290,7 @@
   ([id handler]
    (reg-event-ctx id nil handler))
   ([id interceptors handler]
-   (events/register id [cofx/inject-db
-                        fx/do-fx
-                        flow/interceptor
-                        std-interceptors/inject-global-interceptors
-                        interceptors
-                        (ctx-handler->interceptor handler)])))
+   (-reg-event id interceptors ctx-handler->interceptor handler)))
 
 (defn clear-event
   "Unregisters event handlers (presumably registered previously via the use of `reg-event-db` or `reg-event-fx`).

--- a/src/re_frame/events.cljc
+++ b/src/re_frame/events.cljc
@@ -1,12 +1,11 @@
 (ns re-frame.events
   (:require [re-frame.db          :refer [app-db]]
             [re-frame.utils       :refer [first-in-vector]]
-            [re-frame.interop     :refer [empty-queue debug-enabled?]]
+            [re-frame.interop     :refer [empty-queue debug-enabled? new-uuid]]
             [re-frame.registrar   :refer [get-handler register-handler]]
             [re-frame.loggers     :refer [console]]
             [re-frame.interceptor :as  interceptor]
-            [re-frame.trace       :as trace :include-macros true])
-  #?(:clj (:import [java.util UUID])))
+            [re-frame.trace       :as trace :include-macros true]))
 
 (def kind :event)
 (assert (re-frame.registrar/kinds kind))
@@ -70,10 +69,6 @@
 ;; this var.
 (def ^:dynamic *dispatch-id-capture* nil)
 
-(defn- new-dispatch-id []
-  #?(:cljs (random-uuid)
-     :clj  (UUID/randomUUID)))
-
 (defn handle
   "Given an event vector `event-v`, look up the associated interceptor chain, and execute it."
   [event-v]
@@ -82,7 +77,7 @@
       (if *handling*
         (console :error "re-frame: while handling" *handling* ", dispatch-sync was called for" event-v ". You can't call dispatch-sync within an event handler.")
         (let [dispatch-id (when (trace/is-trace-enabled?)
-                            (new-dispatch-id))
+                            (new-uuid))
               parent-id   (when dispatch-id
                             (:re-frame/parent-dispatch-id (meta event-v)))]
           (when (and dispatch-id *dispatch-id-capture*)

--- a/src/re_frame/events.cljc
+++ b/src/re_frame/events.cljc
@@ -57,17 +57,17 @@
 (def ^:dynamic *current-dispatch-id* nil)
 
 ;; Hook for callers that need to learn the just-allocated dispatch-id
-;; deterministically. When `binding`-ed to an atom, `handle` `reset!`s
-;; that atom with the freshly-allocated dispatch-id BEFORE the trace
-;; runs, so downstream cb fires (sync on JVM, debounced on JS) can match
-;; by id from the start. Used by `re-frame.router/dispatch-and-settle`
-;; to identify the root of its cascade WITHOUT relying on event-vector
-;; equality against the trace stream — vector equality is ambiguous when
-;; two callers dispatch the same vector concurrently.
+;; deterministically. When bound to a function, `handle` calls it with
+;; the freshly-allocated dispatch-id BEFORE the trace runs, so
+;; downstream cb fires (sync on JVM, debounced on JS) can match by id
+;; from the start. Used by `re-frame.router/dispatch-and-settle` to
+;; identify the root of its cascade WITHOUT relying on event-vector
+;; equality against the trace stream — vector equality is ambiguous
+;; when two callers dispatch the same vector concurrently.
 ;; Gated on `(trace/is-trace-enabled?)` (same gate as dispatch-id
 ;; allocation itself); production trace-off paths read nothing from
 ;; this var.
-(def ^:dynamic *dispatch-id-capture* nil)
+(def ^:dynamic *on-dispatch-id* nil)
 
 (defn handle
   "Given an event vector `event-v`, look up the associated interceptor chain, and execute it."
@@ -80,8 +80,8 @@
                             (new-uuid))
               parent-id   (when dispatch-id
                             (:re-frame/parent-dispatch-id (meta event-v)))]
-          (when (and dispatch-id *dispatch-id-capture*)
-            (reset! *dispatch-id-capture* dispatch-id))
+          (when (and dispatch-id *on-dispatch-id*)
+            (*on-dispatch-id* dispatch-id))
           (binding [*handling*           event-v
                     *current-dispatch-id* dispatch-id]
             (trace/with-trace {:operation event-id

--- a/src/re_frame/interop.clj
+++ b/src/re_frame/interop.clj
@@ -1,5 +1,6 @@
 (ns re-frame.interop
-  (:import [java.util.concurrent Executor Executors ScheduledExecutorService ThreadFactory TimeUnit]))
+  (:import [java.util UUID]
+           [java.util.concurrent Executor Executors ScheduledExecutorService ThreadFactory TimeUnit]))
 
 ;; The purpose of this file is to provide JVM-runnable implementations of the
 ;; CLJS equivalents in interop.cljs.
@@ -36,6 +37,9 @@
 (def after-render next-tick)
 
 (def debug-enabled? true)
+
+(defn new-uuid []
+  (UUID/randomUUID))
 
 (defn ratom [x]
   (atom x))

--- a/src/re_frame/interop.clj
+++ b/src/re_frame/interop.clj
@@ -23,7 +23,12 @@
 (defn on-load
   [listener]) ;; no-op
 
-(defonce ^:private executor (Executors/newSingleThreadExecutor))
+(defonce ^:private executor
+  (Executors/newSingleThreadExecutor
+   (reify ThreadFactory
+     (newThread [_ r]
+       (doto (Thread. r "re-frame-next-tick")
+         (.setDaemon true))))))
 
 (defonce ^:private on-dispose-callbacks (atom {}))
 

--- a/src/re_frame/interop.cljs
+++ b/src/re_frame/interop.cljs
@@ -23,6 +23,9 @@
 ;; https://developers.google.com/closure/compiler/docs/js-for-compiler
 (def ^boolean debug-enabled? "@define {boolean}" ^boolean goog/DEBUG)
 
+(defn new-uuid []
+  (random-uuid))
+
 (defn ratom [x]
   (reagent.core/atom x))
 

--- a/src/re_frame/macros.cljc
+++ b/src/re_frame/macros.cljc
@@ -65,6 +65,33 @@
             [re-frame.interop]
             [re-frame.registrar]))
 
+;; -- dispatch / dispatch-sync / subscribe ------------------------------------
+;;
+;; All three forward a single user-supplied vector to a `re-frame.core` fn
+;; and, in DEBUG builds, attach a `{:file :line}` `:re-frame/source` meta
+;; first. The shape is identical across the three; only the target fn
+;; differs — so `-source-meta-call` builds the expansion form and the
+;; public macros are 1-line delegates.
+
+#?(:clj
+(defn- -source-meta-call
+  "Emit the macroexpansion form for a single-arg call to `target-sym`,
+   wrapping the user-supplied value `v` with `:re-frame/source` meta in
+   DEBUG builds and passing it through bare in non-DEBUG builds. The
+   user expression is bound once so both branches reuse the same value
+   without re-evaluating side-effects.
+
+   `target-sym` is the fully-qualified `re-frame.core/...` symbol;
+   `form`/`env` are the calling macro's `&form` / `&env`. `(:file env)`
+   is preferred over `*file*` so CLJS expansion picks up the call-site
+   file from `&env` rather than the macros.cljc compile context."
+  [target-sym v form env]
+  (let [src-meta {:file (or (:file env) *file*) :line (:line (meta form))}]
+    `(let [v# ~v]
+       (if re-frame.interop/debug-enabled?
+         (~target-sym (vary-meta v# assoc :re-frame/source ~src-meta))
+         (~target-sym v#))))))
+
 (defmacro dispatch
   "Like `re-frame.core/dispatch` but in DEBUG builds attaches
    `{:file :line}` on the event vector as `:re-frame/source`
@@ -79,12 +106,7 @@
    metadata survives the merge."
   {:arglists '([event-v])}
   [event-v]
-  (let [src-meta {:file (or (:file &env) *file*) :line (:line (meta &form))}]
-    `(let [ev# ~event-v]
-       (if re-frame.interop/debug-enabled?
-         (re-frame.core/dispatch
-           (vary-meta ev# assoc :re-frame/source ~src-meta))
-         (re-frame.core/dispatch ev#)))))
+  (-source-meta-call 're-frame.core/dispatch event-v &form &env))
 
 (defmacro dispatch-sync
   "Like `re-frame.core/dispatch-sync` but attaches call-site source
@@ -92,12 +114,7 @@
    behaviour."
   {:arglists '([event-v])}
   [event-v]
-  (let [src-meta {:file (or (:file &env) *file*) :line (:line (meta &form))}]
-    `(let [ev# ~event-v]
-       (if re-frame.interop/debug-enabled?
-         (re-frame.core/dispatch-sync
-           (vary-meta ev# assoc :re-frame/source ~src-meta))
-         (re-frame.core/dispatch-sync ev#)))))
+  (-source-meta-call 're-frame.core/dispatch-sync event-v &form &env))
 
 (defmacro subscribe
   "Like `re-frame.core/subscribe` but in DEBUG builds attaches
@@ -117,12 +134,7 @@
    without any new emission)."
   {:arglists '([query-v])}
   [query-v]
-  (let [src-meta {:file (or (:file &env) *file*) :line (:line (meta &form))}]
-    `(let [qv# ~query-v]
-       (if re-frame.interop/debug-enabled?
-         (re-frame.core/subscribe
-           (vary-meta qv# assoc :re-frame/source ~src-meta))
-         (re-frame.core/subscribe qv#)))))
+  (-source-meta-call 're-frame.core/subscribe query-v &form &env))
 
 ;; -- registration macros -----------------------------------------------------
 ;;

--- a/src/re_frame/macros.cljc
+++ b/src/re_frame/macros.cljc
@@ -74,23 +74,24 @@
 ;; public macros are 1-line delegates.
 
 #?(:clj
-(defn- -source-meta-call
-  "Emit the macroexpansion form for a single-arg call to `target-sym`,
-   wrapping the user-supplied value `v` with `:re-frame/source` meta in
-   DEBUG builds and passing it through bare in non-DEBUG builds. The
-   user expression is bound once so both branches reuse the same value
-   without re-evaluating side-effects.
+   (defn- -source-meta-call
+     "Emit the macroexpansion form for a call to `target-sym`, wrapping
+      the first user-supplied value `v` with `:re-frame/source` meta in
+      DEBUG builds and passing it through bare in non-DEBUG builds. The
+      first user expression is bound once so both branches reuse the same
+      value without re-evaluating side-effects. Any extra args are passed
+      through unchanged after that first value.
 
    `target-sym` is the fully-qualified `re-frame.core/...` symbol;
    `form`/`env` are the calling macro's `&form` / `&env`. `(:file env)`
    is preferred over `*file*` so CLJS expansion picks up the call-site
    file from `&env` rather than the macros.cljc compile context."
-  [target-sym v form env]
-  (let [src-meta {:file (or (:file env) *file*) :line (:line (meta form))}]
-    `(let [v# ~v]
-       (if re-frame.interop/debug-enabled?
-         (~target-sym (vary-meta v# assoc :re-frame/source ~src-meta))
-         (~target-sym v#))))))
+     [target-sym v form env & args]
+     (let [src-meta {:file (or (:file env) *file*) :line (:line (meta form))}]
+       `(let [v# ~v]
+          (if re-frame.interop/debug-enabled?
+            (~target-sym (vary-meta v# assoc :re-frame/source ~src-meta) ~@args)
+            (~target-sym v# ~@args))))))
 
 (defmacro dispatch
   "Like `re-frame.core/dispatch` but in DEBUG builds attaches
@@ -131,10 +132,16 @@
    Recover the meta'd query-v via `re-frame.subs/query-v-for-reaction`
    on the returned reaction, or read the `:input-query-vs` tag on
    `:sub/run` traces (downstream consumers see the meta'd vectors
-   without any new emission)."
-  {:arglists '([query-v])}
-  [query-v]
-  (-source-meta-call 're-frame.core/subscribe query-v &form &env))
+   without any new emission).
+
+   Supports the same arities as `re-frame.core/subscribe`, including
+   the historical `[query-v dynv]` form. Source metadata is attached
+   to `query-v`; `dynv` is passed through unchanged."
+  {:arglists '([query-v] [query-v dynv])}
+  ([query-v]
+   (-source-meta-call 're-frame.core/subscribe query-v &form &env))
+  ([query-v dynv]
+   (-source-meta-call 're-frame.core/subscribe query-v &form &env dynv)))
 
 ;; -- registration macros -----------------------------------------------------
 ;;

--- a/src/re_frame/macros.cljc
+++ b/src/re_frame/macros.cljc
@@ -151,6 +151,30 @@
 ;; boot, so the runtime cost matters less than for dispatch/subscribe,
 ;; but the gate keeps the symmetry and lets builds that flip
 ;; `goog.DEBUG=false` shed the `-decorate-handler-meta!` call entirely.
+;;
+;; The three reg-event-XX macros share their expansion shape — only
+;; the target symbol and the trailing arguments differ — so
+;; `-reg-event-call` builds the form once and the public macros are
+;; 1-line delegates per arity. `reg-sub` and `reg-fx` keep their own
+;; bodies because their handler-kind tag (`:sub` / `:fx`) and call
+;; shape differ from the event family.
+
+#?(:clj
+(defn- -reg-event-call
+  "Emit the macroexpansion form for a reg-event-XX macro that captures
+   call-site source metadata on the registered interceptor chain in
+   DEBUG builds. `target-sym` is the fully-qualified
+   `re-frame.core/reg-event-XX` symbol; `id` is the registration id;
+   `args` is the vector of trailing user-supplied args to splice into
+   the call (handler, or interceptors + handler). `form` / `env` are
+   the calling macro's `&form` / `&env`."
+  [target-sym id args form env]
+  (let [src-meta {:file (or (:file env) *file*) :line (:line (meta form))}]
+    `(if re-frame.interop/debug-enabled?
+       (let [r# (~target-sym ~id ~@args)]
+         (re-frame.registrar/-decorate-handler-meta! :event ~id ~src-meta)
+         r#)
+       (~target-sym ~id ~@args)))))
 
 (defmacro reg-event-db
   "Like `re-frame.core/reg-event-db` but in DEBUG builds attaches
@@ -164,19 +188,9 @@
    `re-frame.core/reg-event-db` instead."
   {:arglists '([id handler] [id interceptors handler])}
   ([id handler]
-   (let [src-meta {:file (or (:file &env) *file*) :line (:line (meta &form))}]
-     `(if re-frame.interop/debug-enabled?
-        (let [r# (re-frame.core/reg-event-db ~id ~handler)]
-          (re-frame.registrar/-decorate-handler-meta! :event ~id ~src-meta)
-          r#)
-        (re-frame.core/reg-event-db ~id ~handler))))
+   (-reg-event-call 're-frame.core/reg-event-db id [handler] &form &env))
   ([id interceptors handler]
-   (let [src-meta {:file (or (:file &env) *file*) :line (:line (meta &form))}]
-     `(if re-frame.interop/debug-enabled?
-        (let [r# (re-frame.core/reg-event-db ~id ~interceptors ~handler)]
-          (re-frame.registrar/-decorate-handler-meta! :event ~id ~src-meta)
-          r#)
-        (re-frame.core/reg-event-db ~id ~interceptors ~handler)))))
+   (-reg-event-call 're-frame.core/reg-event-db id [interceptors handler] &form &env)))
 
 (defmacro reg-event-fx
   "Like `re-frame.core/reg-event-fx` but attaches call-site source
@@ -184,19 +198,9 @@
    `reg-event-db` for the rationale and DCE behaviour."
   {:arglists '([id handler] [id interceptors handler])}
   ([id handler]
-   (let [src-meta {:file (or (:file &env) *file*) :line (:line (meta &form))}]
-     `(if re-frame.interop/debug-enabled?
-        (let [r# (re-frame.core/reg-event-fx ~id ~handler)]
-          (re-frame.registrar/-decorate-handler-meta! :event ~id ~src-meta)
-          r#)
-        (re-frame.core/reg-event-fx ~id ~handler))))
+   (-reg-event-call 're-frame.core/reg-event-fx id [handler] &form &env))
   ([id interceptors handler]
-   (let [src-meta {:file (or (:file &env) *file*) :line (:line (meta &form))}]
-     `(if re-frame.interop/debug-enabled?
-        (let [r# (re-frame.core/reg-event-fx ~id ~interceptors ~handler)]
-          (re-frame.registrar/-decorate-handler-meta! :event ~id ~src-meta)
-          r#)
-        (re-frame.core/reg-event-fx ~id ~interceptors ~handler)))))
+   (-reg-event-call 're-frame.core/reg-event-fx id [interceptors handler] &form &env)))
 
 (defmacro reg-event-ctx
   "Like `re-frame.core/reg-event-ctx` but attaches call-site source
@@ -204,19 +208,9 @@
    `reg-event-db` for the rationale and DCE behaviour."
   {:arglists '([id handler] [id interceptors handler])}
   ([id handler]
-   (let [src-meta {:file (or (:file &env) *file*) :line (:line (meta &form))}]
-     `(if re-frame.interop/debug-enabled?
-        (let [r# (re-frame.core/reg-event-ctx ~id ~handler)]
-          (re-frame.registrar/-decorate-handler-meta! :event ~id ~src-meta)
-          r#)
-        (re-frame.core/reg-event-ctx ~id ~handler))))
+   (-reg-event-call 're-frame.core/reg-event-ctx id [handler] &form &env))
   ([id interceptors handler]
-   (let [src-meta {:file (or (:file &env) *file*) :line (:line (meta &form))}]
-     `(if re-frame.interop/debug-enabled?
-        (let [r# (re-frame.core/reg-event-ctx ~id ~interceptors ~handler)]
-          (re-frame.registrar/-decorate-handler-meta! :event ~id ~src-meta)
-          r#)
-        (re-frame.core/reg-event-ctx ~id ~interceptors ~handler)))))
+   (-reg-event-call 're-frame.core/reg-event-ctx id [interceptors handler] &form &env)))
 
 (defmacro reg-sub
   "Like `re-frame.core/reg-sub` but in DEBUG builds attaches

--- a/src/re_frame/macros.cljc
+++ b/src/re_frame/macros.cljc
@@ -74,6 +74,20 @@
 ;; public macros are 1-line delegates.
 
 #?(:clj
+   (defn- -source-meta
+     "Return call-site source metadata for a macro invocation.
+
+      In CLJS builds, shadow-cljs does not reliably populate `:file`
+      in `&env`, while the reader does attach `:file` and `:line` to
+      the invocation form. Prefer form metadata for both fields, then
+      fall back to `&env` / `*file*` for macro-generated forms that
+      lack reader metadata."
+     [form env]
+     (let [form-meta (meta form)]
+       {:file (or (:file form-meta) (:file env) *file*)
+        :line (:line form-meta)})))
+
+#?(:clj
    (defn- -source-meta-call
      "Emit the macroexpansion form for a call to `target-sym`, wrapping
       the first user-supplied value `v` with `:re-frame/source` meta in
@@ -83,11 +97,17 @@
       through unchanged after that first value.
 
    `target-sym` is the fully-qualified `re-frame.core/...` symbol;
-   `form`/`env` are the calling macro's `&form` / `&env`. `(:file env)`
-   is preferred over `*file*` so CLJS expansion picks up the call-site
-   file from `&env` rather than the macros.cljc compile context."
+   `form`/`env` are the calling macro's `&form` / `&env`. `:file` and
+   `:line` both come from `(meta form)` — that's the metadata the
+   CLJS reader attaches to the macro-invocation form when reading
+   from a source file (mirrors `re-com.core/at`, which has captured
+   call-site file/line in CLJS this way for years). `:file env` is
+   tried as a secondary fallback in case form-meta is missing (e.g.
+   macro called from inside another macro's expansion); `*file*` is
+   the JVM-side last-resort, useful only when the CLJS reader didn't
+   reach this form (rare)."
      [target-sym v form env & args]
-     (let [src-meta {:file (or (:file env) *file*) :line (:line (meta form))}]
+     (let [src-meta (-source-meta form env)]
        `(let [v# ~v]
           (if re-frame.interop/debug-enabled?
             (~target-sym (vary-meta v# assoc :re-frame/source ~src-meta) ~@args)
@@ -185,7 +205,7 @@
    the call (handler, or interceptors + handler). `form` / `env` are
    the calling macro's `&form` / `&env`."
   [target-sym id args form env]
-  (let [src-meta {:file (or (:file env) *file*) :line (:line (meta form))}]
+  (let [src-meta (-source-meta form env)]
     `(if re-frame.interop/debug-enabled?
        (let [r# (~target-sym ~id ~@args)]
          (re-frame.registrar/-decorate-handler-meta! :event ~id ~src-meta)
@@ -243,7 +263,7 @@
    sibling registration source-meta macros."
   {:arglists '([query-id & args])}
   [query-id & args]
-  (let [src-meta {:file (or (:file &env) *file*) :line (:line (meta &form))}]
+  (let [src-meta (-source-meta &form &env)]
     `(if re-frame.interop/debug-enabled?
        (let [r# (re-frame.core/reg-sub ~query-id ~@args)]
          (re-frame.registrar/-decorate-handler-meta! :sub ~query-id ~src-meta)
@@ -261,7 +281,7 @@
    sibling registration source-meta macros."
   {:arglists '([id handler])}
   [id handler]
-  (let [src-meta {:file (or (:file &env) *file*) :line (:line (meta &form))}]
+  (let [src-meta (-source-meta &form &env)]
     `(if re-frame.interop/debug-enabled?
        (let [r# (re-frame.core/reg-fx ~id ~handler)]
          (re-frame.registrar/-decorate-handler-meta! :fx ~id ~src-meta)

--- a/src/re_frame/macros.cljc
+++ b/src/re_frame/macros.cljc
@@ -104,7 +104,10 @@
    the existing trace's `:event` tag.
 
    The macro uses standard `vary-meta` so any user-supplied event
-   metadata survives the merge."
+   metadata survives the merge.
+
+   See also: `dispatch-sync` and `subscribe` in this namespace for
+   the other DEBUG source-meta call-site macros."
   {:arglists '([event-v])}
   [event-v]
   (-source-meta-call 're-frame.core/dispatch event-v &form &env))
@@ -112,7 +115,10 @@
 (defmacro dispatch-sync
   "Like `re-frame.core/dispatch-sync` but attaches call-site source
    meta in DEBUG builds. See `dispatch` for the rationale and DCE
-   behaviour."
+   behaviour.
+
+   See also: `dispatch` and `subscribe` in this namespace for the
+   other DEBUG source-meta call-site macros."
   {:arglists '([event-v])}
   [event-v]
   (-source-meta-call 're-frame.core/dispatch-sync event-v &form &env))
@@ -136,7 +142,10 @@
 
    Supports the same arities as `re-frame.core/subscribe`, including
    the historical `[query-v dynv]` form. Source metadata is attached
-   to `query-v`; `dynv` is passed through unchanged."
+   to `query-v`; `dynv` is passed through unchanged.
+
+   See also: `dispatch` and `dispatch-sync` in this namespace for the
+   event-dispatch source-meta call-site macros."
   {:arglists '([query-v] [query-v dynv])}
   ([query-v]
    (-source-meta-call 're-frame.core/subscribe query-v &form &env))
@@ -228,7 +237,10 @@
 
    Variadic — supports the same `:<-` / `:->` / `:=>` sugar pairs as
    `re-frame.core/reg-sub`. Macro, so `(apply reg-sub ...)` won't
-   compile; use `re-frame.core/reg-sub` for that."
+   compile; use `re-frame.core/reg-sub` for that.
+
+   See also: `reg-event-db` and `reg-fx` in this namespace for the
+   sibling registration source-meta macros."
   {:arglists '([query-id & args])}
   [query-id & args]
   (let [src-meta {:file (or (:file &env) *file*) :line (:line (meta &form))}]
@@ -243,7 +255,10 @@
    `{:file :line}` as metadata on the registered effect handler so
    `(meta (re-frame.registrar/get-handler :fx id))` returns the
    call-site location. Production CLJS builds emit a bare
-   `re-frame.core/reg-fx` call after Closure DCE."
+   `re-frame.core/reg-fx` call after Closure DCE.
+
+   See also: `reg-event-db` and `reg-sub` in this namespace for the
+   sibling registration source-meta macros."
   {:arglists '([id handler])}
   [id handler]
   (let [src-meta {:file (or (:file &env) *file*) :line (:line (meta &form))}]

--- a/src/re_frame/router.cljc
+++ b/src/re_frame/router.cljc
@@ -1,9 +1,8 @@
 (ns re-frame.router
   (:require [re-frame.events  :as events :refer [handle]]
-            [re-frame.interop :as interop :refer [after-render empty-queue next-tick]]
+            [re-frame.interop :as interop :refer [after-render empty-queue new-uuid next-tick]]
             [re-frame.loggers :refer [console]]
-            [re-frame.trace   :as trace :include-macros true])
-  #?(:clj (:import [java.util UUID])))
+            [re-frame.trace   :as trace :include-macros true]))
 
 ;; -- Router Loop ------------------------------------------------------------
 ;;
@@ -360,10 +359,6 @@
 ;;   settled if a slow async chain pauses for longer than
 ;;   `:settle-window-ms` before re-firing a child :dispatch.
 ;;   Bump the window for those cases.
-
-(defn- new-uuid []
-  #?(:cljs (random-uuid)
-     :clj  (UUID/randomUUID)))
 
 (defn- mk-deferred []
   ;; Cross-platform deferred: returns

--- a/src/re_frame/router.cljc
+++ b/src/re_frame/router.cljc
@@ -314,6 +314,8 @@
 ;;                              ; cascade epoch landed before resolving)
 ;;       :include-cascaded? bool ; default true — emit :cascaded-epochs
 ;;                               ; (children fired via :fx [:dispatch ...])
+;;       :overrides map         ; fx-id -> stub-fn, as in dispatch-with;
+;;                              ; inherited by the synchronous cascade
 ;;
 ;; Resolves to:
 ;;   {:ok? true :root-epoch <epoch> :cascaded-epochs [<epoch> ...]}
@@ -554,9 +556,14 @@
    `:fx [:dispatch ...]` children. See the long comment above for
    shape, semantics, and limitations."
   ([event] (dispatch-and-settle event {}))
-  ([event {:keys [timeout-ms settle-window-ms include-cascaded?]
-           :or   {timeout-ms 5000 settle-window-ms 100 include-cascaded? true}}]
-   (let [{:keys [value resolve!]} (mk-deferred)
+  ([event opts]
+   (let [opts (or opts {})
+         {:keys [timeout-ms settle-window-ms include-cascaded?]
+          :or   {timeout-ms 5000 settle-window-ms 100 include-cascaded? true}} opts
+         dispatch-event (if (contains? opts :overrides)
+                          (vary-meta event assoc :re-frame/fx-overrides (:overrides opts))
+                          event)
+         {:keys [value resolve!]} (mk-deferred)
          root-id        (atom nil)
          tracker        (mk-tracker root-id)
          settle-tick    (atom 0)            ;; bumped on each cascade signal
@@ -629,7 +636,7 @@
      ;; post-event-callback fallback path picks up events by ordering
      ;; instead.
      (binding [events/*dispatch-id-capture* root-id]
-       (dispatch-sync event))
+       (dispatch-sync dispatch-event))
      (-after-root-dispatched! tracker)
      ;; Even with no children queued, schedule an initial settle
      ;; check so the root-only case resolves promptly.

--- a/src/re_frame/router.cljc
+++ b/src/re_frame/router.cljc
@@ -322,7 +322,10 @@
 ;;   {:ok? false :reason :timeout :event ev :captured-epochs [...]}
 ;;
 ;; CLJS returns a JS Promise; CLJ returns a `clojure.core/promise`
-;; (deref-able). Avoids a core.async dep on either platform.
+;; (deref-able). Avoids a core.async dep on either platform. The
+;; resolved value is a Clojure map on both platforms — JS Promises
+;; carry opaque values, so CLJS callers receive the same map as CLJ
+;; callers without a lossy js->clj conversion.
 ;;
 ;; Settles when the synchronous cascade quietens — the root event
 ;; plus every descendant whose `:parent-dispatch-id` chains back to
@@ -366,7 +369,12 @@
   ;; Cross-platform deferred: returns
   ;;   {:value <promise/atom>      ; what we hand back to the caller
   ;;    :resolve! (fn [v] ...)     ; idempotent, single-shot}
-  ;; CLJS uses a JS Promise (resolve! captured from the executor).
+  ;; CLJS uses a JS Promise (resolve! captured from the executor); the
+  ;; resolved value is the raw Clojure map — JS Promises carry opaque
+  ;; values fine, and re-frame's CLJS callers want Clojure data without
+  ;; a lossy js->clj round-trip (clj->js's :keyword-fn name strips
+  ;; namespaces, collapsing keys like :app-db/before and :event/before
+  ;; into the same string).
   ;; CLJ uses clojure.core/promise (deliver is idempotent under guard).
   #?(:cljs
      (let [resolve-fn (volatile! nil)
@@ -376,7 +384,7 @@
        {:value     p
         :resolve!  (fn [v]
                      (when (compare-and-set! done? false true)
-                       (@resolve-fn (clj->js v :keyword-fn name))))})
+                       (@resolve-fn v)))})
      :clj
      (let [p (promise)]
        {:value    p

--- a/src/re_frame/router.cljc
+++ b/src/re_frame/router.cljc
@@ -179,7 +179,7 @@
         ;; relationships are carried explicitly on event metadata.
         (binding [events/*handling* nil
                   events/*current-dispatch-id* nil
-                  events/*dispatch-id-capture* nil
+                  events/*on-dispatch-id* nil
                   trace/*current-trace* nil]
           (handle event-v))
         (set! queue (pop queue))
@@ -488,7 +488,7 @@
   ICascadeTracker
   (-register! [_ on-cascade]
     ;; Match by dispatch-id only: (a) :dispatch-id == root-id (root, set
-    ;; inside `handle` via *dispatch-id-capture* before any cb fires), or
+    ;; inside `handle` via *on-dispatch-id* before any cb fires), or
     ;; (b) :parent-dispatch-id ∈ cascade-ids (already-matched ancestor).
     ;; No event-vector fallback: when two callers dispatch the same vector,
     ;; vector equality is ambiguous and would mis-attribute one caller's
@@ -637,17 +637,17 @@
                           :event           event
                           :captured-epochs (-captured tracker)}))
               timeout-ms))
-     ;; Dispatch the root synchronously, binding `*dispatch-id-capture*`
-     ;; so `handle` writes the freshly-allocated dispatch-id directly
+     ;; Dispatch the root synchronously, binding `*on-dispatch-id*`
+     ;; so `handle` publishes the freshly-allocated dispatch-id directly
      ;; into `root-id` BEFORE the trace fires the cb. Children queued
      ;; via :fx [:dispatch ...] fire later via the router queue;
      ;; epoch-cb picks them up as they land and matches them by
      ;; :parent-dispatch-id ∈ cascade-ids. With tracing off, `handle`
-     ;; leaves root-id nil because it only reads *dispatch-id-capture*
+     ;; leaves root-id nil because it only reads *on-dispatch-id*
      ;; when tracing is enabled; the
      ;; post-event-callback fallback path picks up events by ordering
      ;; instead.
-     (binding [events/*dispatch-id-capture* root-id]
+     (binding [events/*on-dispatch-id* #(reset! root-id %)]
        (dispatch-sync dispatch-event))
      (-after-root-dispatched! tracker)
      ;; Even with no children queued, schedule an initial settle

--- a/src/re_frame/router.cljc
+++ b/src/re_frame/router.cljc
@@ -248,15 +248,20 @@
   #?(:clj  (instance? clojure.lang.IObj x)
      :cljs (satisfies? IWithMeta x)))
 
-(defn- assoc-meta-if-possible [event k v]
-  (if (can-carry-meta? event)
-    (vary-meta event assoc k v)
-    event))
+(defn- inherit-event-meta
+  ([event k v]
+   (inherit-event-meta event k v true))
+  ([event k v overwrite?]
+   (if (or (nil? v)
+           (and (not overwrite?) (some-> event meta k))
+           (not (can-carry-meta? event)))
+     event
+     (vary-meta event assoc k v))))
 
 (defn- tag-with-parent-dispatch-id [event]
-  (if-let [parent-id events/*current-dispatch-id*]
-    (assoc-meta-if-possible event :re-frame/parent-dispatch-id parent-id)
-    event))
+  (inherit-event-meta event
+                      :re-frame/parent-dispatch-id
+                      events/*current-dispatch-id*))
 
 ;; Fx-overrides cascade propagation. When a child is
 ;; dispatched from inside a handler whose root carried
@@ -267,11 +272,10 @@
 ;; through. Idempotent — if the child already has overrides set
 ;; (multi-level dispatch-with), we keep the existing one.
 (defn- tag-with-fx-overrides [event]
-  (if (some-> event meta :re-frame/fx-overrides)
-    event
-    (if-let [overrides (some-> events/*handling* meta :re-frame/fx-overrides)]
-      (assoc-meta-if-possible event :re-frame/fx-overrides overrides)
-      event)))
+  (inherit-event-meta event
+                      :re-frame/fx-overrides
+                      (some-> events/*handling* meta :re-frame/fx-overrides)
+                      false))
 
 (defn dispatch
   [event]

--- a/src/re_frame/router.cljc
+++ b/src/re_frame/router.cljc
@@ -244,9 +244,18 @@
 ;; (and re-frame already forbids dispatch-sync from within an event
 ;; handler anyway, so the parent-chain across dispatch-sync is
 ;; structurally a non-issue).
+(defn- can-carry-meta? [x]
+  #?(:clj  (instance? clojure.lang.IObj x)
+     :cljs (satisfies? IWithMeta x)))
+
+(defn- assoc-meta-if-possible [event k v]
+  (if (can-carry-meta? event)
+    (vary-meta event assoc k v)
+    event))
+
 (defn- tag-with-parent-dispatch-id [event]
   (if-let [parent-id events/*current-dispatch-id*]
-    (vary-meta event assoc :re-frame/parent-dispatch-id parent-id)
+    (assoc-meta-if-possible event :re-frame/parent-dispatch-id parent-id)
     event))
 
 ;; Fx-overrides cascade propagation. When a child is
@@ -261,7 +270,7 @@
   (if (some-> event meta :re-frame/fx-overrides)
     event
     (if-let [overrides (some-> events/*handling* meta :re-frame/fx-overrides)]
-      (vary-meta event assoc :re-frame/fx-overrides overrides)
+      (assoc-meta-if-possible event :re-frame/fx-overrides overrides)
       event)))
 
 (defn dispatch

--- a/src/re_frame/router.cljc
+++ b/src/re_frame/router.cljc
@@ -470,23 +470,38 @@
   {:cascade-ids      #{}
    :seen-ids         #{}
    :cascade-epochs   []
-   :pending-children {}})
+   :pending-children {}
+   :unmatched-epochs []})
 
-(defn- accept-trace-epoch [root-id changed? state epoch]
+(defn- trace-epoch-accepted? [root-id state epoch]
   (let [id        (:dispatch-id epoch)
         parent-id (:parent-dispatch-id epoch)]
-    (if (and (not (contains? (:seen-ids state) id))
-             (or (= root-id id)
-                 (contains? (:cascade-ids state) parent-id)))
-      (let [expected (count (immediate-dispatch-events (:effects epoch)))]
-        (reset! changed? true)
-        (cond-> (-> state
-                    (update :seen-ids conj id)
-                    (update :pending-children decrement-pending-child parent-id)
-                    (update :cascade-epochs conj epoch))
-          (pos? expected) (update-in [:pending-children id] (fnil + 0) expected)
-          true            (update :cascade-ids conj id)))
-      state)))
+    (and (not (contains? (:seen-ids state) id))
+         (or (= root-id id)
+             (contains? (:cascade-ids state) parent-id)))))
+
+(defn- accept-trace-epoch [state epoch]
+  (let [id        (:dispatch-id epoch)
+        parent-id (:parent-dispatch-id epoch)
+        expected  (count (immediate-dispatch-events (:effects epoch)))]
+    (cond-> (-> state
+                (update :seen-ids conj id)
+                (update :pending-children decrement-pending-child parent-id)
+                (update :cascade-epochs conj epoch))
+      (pos? expected) (update-in [:pending-children id] (fnil + 0) expected)
+      true            (update :cascade-ids conj id))))
+
+(defn- process-trace-epochs [root-id changed? state epochs]
+  (loop [state (update state :unmatched-epochs into epochs)]
+    (let [{accepted true pending false}
+          (group-by #(trace-epoch-accepted? root-id state %)
+                    (:unmatched-epochs state))]
+      (if (seq accepted)
+        (do
+          (reset! changed? true)
+          (recur (assoc (reduce accept-trace-epoch state accepted)
+                        :unmatched-epochs (vec pending))))
+        (assoc state :unmatched-epochs (vec pending))))))
 
 (deftype TraceTracker [cb-key root-id state]
   ICascadeTracker
@@ -501,11 +516,7 @@
                              (fn [epochs]
                                (let [changed? (atom false)]
                                  (swap! state
-                                        (fn [s]
-                                          (reduce (fn [s e]
-                                                    (accept-trace-epoch @root-id changed? s e))
-                                                  s
-                                                  epochs)))
+                                        #(process-trace-epochs @root-id changed? % epochs))
                                  (when @changed?
                                    (on-cascade))))))
   (-unregister! [_]

--- a/src/re_frame/trace.cljc
+++ b/src/re_frame/trace.cljc
@@ -83,6 +83,22 @@
     :optional #{:dispatch-id :parent-dispatch-id}
     :doc "do-fx interceptor — fires registered fx handlers for the event's :effects map."}
 
+   :sync
+   {:required #{}
+    :optional #{}
+    :doc "Synchronous dispatch boundary — emitted after dispatch-sync runs the event and post-event callbacks."}
+
+   :re-frame.router/fsm-trigger
+   {:required #{}
+    :optional #{:current-state :new-state}
+    :doc "Router queue state-machine transition. Fires as the dispatch queue changes state."}
+
+   :flow
+   {:required #{:flow-spec :transition :db :new-db :id->in :id->old-in
+                :id->live-in :id->old-live-in}
+    :optional #{}
+    :doc "Flow alpha transition — emitted when a registered flow updates its derived output."}
+
    :sub/create
    {:required #{:query-v}
     :optional #{:cached? :reaction
@@ -125,12 +141,7 @@
    :reagent/quiescent
    {:required #{}
     :optional #{}
-    :doc "Reagent render queue is idle — emitted by re-frame-10x's batching patch."}
-
-   :sync
-   {:required #{}
-    :optional #{}
-    :doc "End-of-`dispatch-sync` marker."}})
+    :doc "Reagent render queue is idle — emitted by re-frame-10x's batching patch."}})
 
 (defonce ^:private validate-trace?-flag (atom false))
 

--- a/src/re_frame/trace.cljc
+++ b/src/re_frame/trace.cljc
@@ -409,7 +409,7 @@
              duration# (- end# (:start ~trace))
              finished# (assoc ~trace
                               :duration duration#
-                              :end (interop/now))]
+                              :end end#)]
          (when (validate-trace?)
            (check-trace-against-schema finished#))
          (swap! traces conj finished#)

--- a/src/re_frame/trace.cljc
+++ b/src/re_frame/trace.cljc
@@ -143,7 +143,7 @@
     :optional #{}
     :doc "Reagent render queue is idle — emitted by re-frame-10x's batching patch."}})
 
-#?(:cljs (goog-define validate-trace-enabled? false)
+#?(:cljs (def ^boolean validate-trace-enabled? false)
    :clj  (def ^boolean validate-trace-enabled? false))
 
 (defn validate-trace?

--- a/src/re_frame/trace.cljc
+++ b/src/re_frame/trace.cljc
@@ -22,8 +22,8 @@
 ;; self-labels as "Alpha quality". This var is the doc-only
 ;; contract — the canonical answer to "what keys can I rely on?".
 ;;
-;; Doc-only by default. With `validate-trace?` true (a runtime atom
-;; flag, opt-in for dev), `finish-trace` will assert that emitted
+;; Doc-only by default. With trace validation enabled (opt-in for
+;; dev), `finish-trace` will assert that emitted
 ;; tags conform — required keys present, no unknown keys without
 ;; explicit allowance. Production builds leave the flag false; the
 ;; whole machinery is gated on `(is-trace-enabled?)` which itself
@@ -143,7 +143,8 @@
     :optional #{}
     :doc "Reagent render queue is idle — emitted by re-frame-10x's batching patch."}})
 
-(defonce ^:private validate-trace?-flag (atom false))
+#?(:cljs (goog-define validate-trace-enabled? false)
+   :clj  (def ^boolean validate-trace-enabled? false))
 
 (defn validate-trace?
   "True iff the runtime should validate that emitted trace `:tags`
@@ -153,14 +154,15 @@
    `is-trace-enabled?`, but validation adds a per-trace map-walk
    that's not free)."
   []
-  @validate-trace?-flag)
+  validate-trace-enabled?)
 
 (defn set-validate-trace!
   "Enable / disable trace-tag validation. When true, every
    `finish-trace` checks `:tags` against `tag-schema` and warns via
    `console :warn` on missing required keys or unknown keys."
   [enabled?]
-  (reset! validate-trace?-flag (boolean enabled?)))
+  #?(:cljs (set! validate-trace-enabled? (boolean enabled?))
+     :clj  (alter-var-root #'validate-trace-enabled? (constantly (boolean enabled?)))))
 
 (defn check-trace-against-schema
   "Walk a finished trace map and warn about missing/unknown tag
@@ -426,7 +428,7 @@
              finished# (assoc ~trace
                               :duration duration#
                               :end end#)]
-         (when (validate-trace?)
+         (when validate-trace-enabled?
            (check-trace-against-schema finished#))
          (swap! traces conj finished#)
          (run-tracing-callbacks! end#))))

--- a/src/re_frame/trace.cljc
+++ b/src/re_frame/trace.cljc
@@ -208,8 +208,9 @@
   (swap! trace-cbs dissoc key)
   nil)
 
-;; register-epoch-cb. Higher-
-;; level callback that delivers ASSEMBLED EPOCH records — one per
+;; register-epoch-cb.
+;;
+;; Higher-level callback that delivers ASSEMBLED EPOCH records — one per
 ;; `:event` trace — instead of the raw trace stream that
 ;; `register-trace-cb` exposes. Downstream consumers (re-frame-pair,
 ;; re-frame-10x, custom devtools) want the "this dispatch's full

--- a/src/re_frame/trace.cljc
+++ b/src/re_frame/trace.cljc
@@ -209,7 +209,11 @@
 
 (defn register-trace-cb
   "Registers a tracing callback function which will receive a collection of one or more traces.
-  Will replace an existing callback function if it shares the same key."
+  Will replace an existing callback function if it shares the same key.
+
+  See also: `register-epoch-cb` for assembled per-dispatch epoch
+  records, and `tag-schema` for the documented `:tags` shape of
+  emitted traces."
   [key f]
   (if trace-enabled?
     (swap! trace-cbs assoc key f)

--- a/test/re_frame/dispatch_source_meta_test.cljs
+++ b/test/re_frame/dispatch_source_meta_test.cljs
@@ -1,0 +1,104 @@
+(ns re-frame.dispatch-source-meta-test
+  "CLJS coverage for re-frame.macros/dispatch and dispatch-sync source
+   metadata. These tests exercise both the dev branch and a
+   goog.DEBUG=false-equivalent runtime branch via interop/debug-enabled?."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.interop :as interop :refer [set-timeout!]]
+            [re-frame.macros :as rf.m]))
+
+(defn fixture-re-frame
+  []
+  (let [restore-re-frame (atom nil)]
+    {:before #(reset! restore-re-frame (rf/make-restore-fn))
+     :after  #(when-let [restore @restore-re-frame]
+                (restore))}))
+
+(use-fixtures :each (fixture-re-frame))
+
+(deftest dispatch-sync-attaches-source-meta-on-event-vector
+  (testing "rf.m/dispatch-sync attaches {:file :line} as :re-frame/source in CLJS dev mode"
+    (let [captured (atom nil)]
+      (with-redefs [interop/debug-enabled? true]
+        (rf/reg-event-db
+         :dispatch-test/recv-sync
+         (fn [_ event]
+           (reset! captured (meta event))
+           {}))
+        (rf.m/dispatch-sync [:dispatch-test/recv-sync :payload]))
+      (let [m @captured]
+        (is (some? m)
+            "event handler received an event with metadata")
+        (is (some? (:re-frame/source m))
+            ":re-frame/source is present on the event meta")
+        (is (string? (-> m :re-frame/source :file))
+            ":file is a string from the CLJS macro expansion environment")
+        (is (re-find #"dispatch_source_meta_test\.cljs$"
+                     (-> m :re-frame/source :file))
+            ":file points at this test file")
+        (is (pos-int? (-> m :re-frame/source :line))
+            ":line is a positive int from (:line (meta &form))")))))
+
+(deftest dispatch-sync-different-call-sites-have-different-line-numbers
+  (testing "adjacent rf.m/dispatch-sync calls capture distinct :line metadata"
+    (let [a (atom nil)
+          b (atom nil)]
+      (with-redefs [interop/debug-enabled? true]
+        (rf/reg-event-db :dispatch-test/recv-a (fn [_ event] (reset! a (meta event)) {}))
+        (rf/reg-event-db :dispatch-test/recv-b (fn [_ event] (reset! b (meta event)) {}))
+        (rf.m/dispatch-sync [:dispatch-test/recv-a])
+        (rf.m/dispatch-sync [:dispatch-test/recv-b]))
+      (let [la (-> @a :re-frame/source :line)
+            lb (-> @b :re-frame/source :line)]
+        (is (pos-int? la))
+        (is (pos-int? lb))
+        (is (not= la lb)
+            "macros capture the concrete CLJS call-site line")))))
+
+(deftest dispatch-sync-preserves-user-meta-in-dev-mode
+  (testing "user-supplied event metadata survives the macro's vary-meta call"
+    (let [captured (atom nil)]
+      (with-redefs [interop/debug-enabled? true]
+        (rf/reg-event-db :dispatch-test/recv-merge (fn [_ event] (reset! captured (meta event)) {}))
+        (rf.m/dispatch-sync ^:my-flag [:dispatch-test/recv-merge]))
+      (let [m @captured]
+        (is (some? (:re-frame/source m))
+            "macro-added :re-frame/source is present")
+        (is (true? (:my-flag m))
+            "user-supplied :my-flag survives the vary-meta merge")))))
+
+(deftest dispatch-sync-production-branch-does-not-add-source-meta
+  (testing "with debug disabled, the macro branch is a no-op for source metadata"
+    (let [captured (atom nil)]
+      (with-redefs [interop/debug-enabled? false]
+        (rf/reg-event-db :dispatch-test/recv-prod (fn [_ event] (reset! captured (meta event)) {}))
+        (rf.m/dispatch-sync ^:my-flag [:dispatch-test/recv-prod]))
+      (let [m @captured]
+        (is (nil? (:re-frame/source m))
+            "production branch does not attach :re-frame/source")
+        (is (true? (:my-flag m))
+            "production branch passes through the user's event value unchanged")))))
+
+(deftest dispatch-async-source-meta-survives-router-cycle
+  (testing "rf.m/dispatch preserves :re-frame/source through the CLJS async router"
+    (async done
+      (let [captured (atom ::pending)]
+        (with-redefs [interop/debug-enabled? true]
+          (rf/reg-event-db
+           :dispatch-test/recv-async
+           (fn [db event]
+             (reset! captured (meta event))
+             db))
+          (rf.m/dispatch [:dispatch-test/recv-async]))
+        (set-timeout!
+         (fn []
+           (let [m @captured]
+             (is (not= ::pending m)
+                 "async dispatch reached the handler")
+             (is (some? (:re-frame/source m))
+                 ":re-frame/source survives the router push/pop cycle")
+             (is (re-find #"dispatch_source_meta_test\.cljs$"
+                          (-> m :re-frame/source :file))
+                 ":file points at this test file after the queue round-trip")
+             (done)))
+         1000)))))

--- a/test/re_frame/dispatch_with_test.clj
+++ b/test/re_frame/dispatch_with_test.clj
@@ -1,0 +1,286 @@
+(ns re-frame.dispatch-with-test
+  "Tests that `re-frame.core/dispatch-with` and
+   `re-frame.core/dispatch-sync-with` substitute fx handlers via
+   per-event metadata for the duration of the dispatch (and any
+   `:fx [:dispatch ...]` cascade), without leaking into other
+   dispatches and without requiring a try/finally restore.
+
+   These run CLJ-side under cognitect.test-runner — the override
+   propagation machinery is platform-independent: the relevant code
+   lives in `re-frame.core` (`vary-meta` on the event), `re-frame.fx`
+   (`*current-overrides*` + `effect-handler`), and `re-frame.router`
+   (`tag-with-fx-overrides` cascade propagation), all in `.cljc`.
+
+   Coverage targets:
+   - `re-frame.core/dispatch-with` — vary-meta with :re-frame/fx-overrides
+   - `re-frame.core/dispatch-sync-with` — sync variant
+   - `re-frame.fx/*current-overrides*` — dynamic var bound in do-fx-after
+   - `re-frame.fx/effect-handler` — override-or-registrar resolution
+   - `re-frame.router/tag-with-fx-overrides` — cascade propagation"
+  (:require [clojure.test     :refer [deftest is testing use-fixtures]]
+            [re-frame.core    :as rf]
+            [re-frame.db      :as db]
+            [re-frame.loggers :as loggers]
+            [clojure.string   :as str]))
+
+(defn fixture-re-frame
+  [f]
+  (let [restore (rf/make-restore-fn)]
+    (try
+      (f)
+      (finally
+        (restore)))))
+
+(use-fixtures :each fixture-re-frame)
+
+;; ---------------------------------------------------------------------------
+;; Override fires instead of registered handler
+;; ---------------------------------------------------------------------------
+
+(deftest override-fires-instead-of-registered-handler
+  (testing "when dispatch-with provides a stub for an fx-id, the stub
+            runs with the effect value and the registered handler does NOT"
+    (let [registered-calls (atom [])
+          stub-calls       (atom [])
+          delivered        (promise)]
+      (rf/reg-fx :dw-test/fx
+                 (fn [v] (swap! registered-calls conj v)))
+      (rf/reg-event-fx :dw-test/fire
+                       (fn [_ [_ payload]]
+                         {:dw-test/fx payload}))
+      (rf/dispatch-with [:dw-test/fire {:from :stub-test}]
+                        {:dw-test/fx (fn [v]
+                                       (swap! stub-calls conj v)
+                                       (deliver delivered :stub-ran))})
+      (is (= :stub-ran (deref delivered 1000 ::timed-out))
+          "stub fired before timeout — async dispatch reached do-fx-after")
+      (is (= [{:from :stub-test}] @stub-calls)
+          "stub got the effect value the handler returned")
+      (is (empty? @registered-calls)
+          "registered handler did NOT fire — the override took priority"))))
+
+;; ---------------------------------------------------------------------------
+;; :db override leaves the global ratom alone
+;; ---------------------------------------------------------------------------
+
+(deftest db-override-does-not-mutate-global-app-db
+  (testing "an override for :db lets a probe see what the effect would
+            have done to app-db without committing to the global ratom —
+            the docstring claim at re-frame.fx around run-effects!"
+    (reset! db/app-db {:initial true})
+    (let [seen-new-db (promise)]
+      (rf/reg-event-db :dw-test/touch-db
+                       (fn [_db _]
+                         {:probed true}))
+      (rf/dispatch-with [:dw-test/touch-db]
+                        {:db (fn [new-db]
+                               (deliver seen-new-db new-db))})
+      (let [observed (deref seen-new-db 1000 ::timed-out)]
+        (is (not= ::timed-out observed)
+            ":db override fired before timeout")
+        (is (= {:probed true} observed)
+            ":db override receives the new-db the handler returned"))
+      (is (= {:initial true} @db/app-db)
+          "global app-db is untouched — :db override replaced the
+           default reset! with a probe"))))
+
+;; ---------------------------------------------------------------------------
+;; Cascade propagation: child dispatched via :fx [:dispatch ...] inherits
+;; ---------------------------------------------------------------------------
+
+(deftest overrides-propagate-to-fx-dispatch-cascade
+  (testing "a parent dispatched via dispatch-with returning
+            {:fx [[:dispatch [:child]]]} causes the child to inherit the
+            override map — covers tag-with-fx-overrides in router.cljc"
+    (let [parent-calls (atom [])
+          child-calls  (atom [])
+          delivered    (promise)]
+      (rf/reg-fx :dw-test/cascade-fx
+                 (fn [_v]
+                   (throw (ex-info "real :dw-test/cascade-fx ran — override leak"
+                                   {}))))
+      (rf/reg-event-fx :dw-test/parent
+                       (fn [_ _]
+                         {:fx [[:dispatch [:dw-test/child]]]}))
+      (rf/reg-event-fx :dw-test/child
+                       (fn [_ _]
+                         {:dw-test/cascade-fx :child-effect}))
+      (rf/dispatch-with [:dw-test/parent]
+                        {:dw-test/cascade-fx
+                         (fn [v]
+                           (swap! child-calls conj v)
+                           (deliver delivered :child-stub-ran))})
+      (is (= :child-stub-ran (deref delivered 1000 ::timed-out))
+          "child stub fired — overrides crossed the queue boundary
+           via tag-with-fx-overrides")
+      (is (= [:child-effect] @child-calls)
+          "child stub received the child handler's effect value")
+      (is (empty? @parent-calls)
+          "no leak from parent's effects (parent has no :dw-test/cascade-fx)"))))
+
+;; ---------------------------------------------------------------------------
+;; :fx inner effects honour overrides
+;; ---------------------------------------------------------------------------
+
+(deftest fx-inner-effects-honour-overrides
+  (testing "an event that returns {:fx [[:my-fx ...]]} (inner effect of
+            the :fx vector form) fires the override for :my-fx, not the
+            registered handler — covers the effect-handler call inside
+            the :fx handler at re-frame.fx"
+    (let [registered-calls (atom [])
+          stub-calls       (atom [])
+          delivered        (promise)]
+      (rf/reg-fx :dw-test/inner-fx
+                 (fn [v] (swap! registered-calls conj v)))
+      (rf/reg-event-fx :dw-test/fire-inner
+                       (fn [_ _]
+                         {:fx [[:dw-test/inner-fx :inner-payload]]}))
+      (rf/dispatch-with [:dw-test/fire-inner]
+                        {:dw-test/inner-fx
+                         (fn [v]
+                           (swap! stub-calls conj v)
+                           (deliver delivered :stub-ran))})
+      (is (= :stub-ran (deref delivered 1000 ::timed-out))
+          "inner-fx stub fired — *current-overrides* dynamic binding
+           reaches the inline :fx handler too")
+      (is (= [:inner-payload] @stub-calls))
+      (is (empty? @registered-calls)
+          "registered :dw-test/inner-fx did NOT fire — override took priority
+           inside the :fx vector form, not just at the top-level effect map"))))
+
+;; ---------------------------------------------------------------------------
+;; Two overlapping dispatch-with calls don't cross-contaminate
+;; ---------------------------------------------------------------------------
+
+(deftest overlapping-dispatch-with-calls-do-not-cross-contaminate
+  (testing "two dispatch-with calls each carry their own override map in
+            their own event meta — the second call's stub does not
+            observe events from the first, and vice versa — docstring
+            claim around overrides expiring with event scope"
+    (let [a-stub-calls (atom [])
+          b-stub-calls (atom [])
+          a-done       (promise)
+          b-done       (promise)]
+      (rf/reg-fx :dw-test/parallel-fx
+                 (fn [_v]
+                   (throw (ex-info "real :dw-test/parallel-fx ran — override leak"
+                                   {}))))
+      (rf/reg-event-fx :dw-test/a-fire
+                       (fn [_ _]
+                         {:dw-test/parallel-fx :from-a}))
+      (rf/reg-event-fx :dw-test/b-fire
+                       (fn [_ _]
+                         {:dw-test/parallel-fx :from-b}))
+      (rf/dispatch-with [:dw-test/a-fire]
+                        {:dw-test/parallel-fx
+                         (fn [v]
+                           (swap! a-stub-calls conj v)
+                           (deliver a-done :a-ran))})
+      (rf/dispatch-with [:dw-test/b-fire]
+                        {:dw-test/parallel-fx
+                         (fn [v]
+                           (swap! b-stub-calls conj v)
+                           (deliver b-done :b-ran))})
+      (is (= :a-ran (deref a-done 1000 ::timed-out)))
+      (is (= :b-ran (deref b-done 1000 ::timed-out)))
+      (is (= [:from-a] @a-stub-calls)
+          "stub A only saw effects from event A — its own meta carried
+           its own override map")
+      (is (= [:from-b] @b-stub-calls)
+          "stub B only saw effects from event B — meta from A's
+           dispatch-with did not bleed into B's handling frame"))))
+
+;; ---------------------------------------------------------------------------
+;; Override expires at end of event — no try/finally needed
+;; ---------------------------------------------------------------------------
+
+(deftest override-expires-with-the-event
+  (testing "after dispatch-with completes, a subsequent plain dispatch
+            for the same fx-id fires the REAL handler — the override
+            does not leave a stale stub installed anywhere global.
+            This is the no-try/finally claim in dispatch-with's docstring."
+    (let [registered-calls (atom [])
+          stub-calls       (atom [])
+          stub-done        (promise)
+          real-done        (promise)]
+      (rf/reg-fx :dw-test/expiring-fx
+                 (fn [v]
+                   (swap! registered-calls conj v)
+                   (deliver real-done :real-ran)))
+      (rf/reg-event-fx :dw-test/expire-event
+                       (fn [_ [_ token]]
+                         {:dw-test/expiring-fx token}))
+      ;; First dispatch — overridden.
+      (rf/dispatch-with [:dw-test/expire-event :first]
+                        {:dw-test/expiring-fx
+                         (fn [v]
+                           (swap! stub-calls conj v)
+                           (deliver stub-done :stub-ran))})
+      (is (= :stub-ran (deref stub-done 1000 ::timed-out)))
+      ;; Second dispatch — no override; the registered handler must run.
+      (rf/dispatch [:dw-test/expire-event :second])
+      (is (= :real-ran (deref real-done 1000 ::timed-out))
+          "the registered handler fired on the SECOND dispatch — proves
+           the override didn't persist past the first event's scope")
+      (is (= [:first] @stub-calls)
+          "stub only saw the first event")
+      (is (= [:second] @registered-calls)
+          "registered handler only saw the second event"))))
+
+;; ---------------------------------------------------------------------------
+;; Unknown fx-id with no override — warning still fires
+;; ---------------------------------------------------------------------------
+
+(deftest unknown-fx-id-warning-still-fires-without-override
+  (testing "when an event returns an effect for an fx-id that is neither
+            registered nor present in overrides, the existing
+            (console :warn ...) for unknown effects still fires —
+            override path doesn't suppress the diagnostic"
+    (let [warnings         (atom [])
+          original-loggers (loggers/get-loggers)]
+      (try
+        (loggers/set-loggers!
+         {:warn (fn [& args] (swap! warnings conj (apply str args)))})
+        (rf/reg-event-fx :dw-test/unknown-fire
+                         (fn [_ _]
+                           {:dw-test/never-registered :payload}))
+        (rf/dispatch-sync-with [:dw-test/unknown-fire]
+                               {:dw-test/some-other-fx (fn [_] :ignored)})
+        (is (some #(str/includes? % ":dw-test/never-registered") @warnings)
+            "the unknown-effect warning still mentions the missing fx-id
+             when overrides are present but don't cover it")
+        (finally
+          (loggers/set-loggers! original-loggers))))))
+
+;; ---------------------------------------------------------------------------
+;; dispatch-sync-with — sync variant reads the same override meta
+;; ---------------------------------------------------------------------------
+
+(deftest dispatch-sync-with-applies-overrides-on-the-sync-path
+  (testing "dispatch-sync-with takes the synchronous handle path but
+            still threads the override map through do-fx-after — same
+            mechanism as dispatch-with, no separate sync-only code path"
+    (let [registered-calls (atom [])
+          stub-calls       (atom [])]
+      (rf/reg-fx :dw-test/sync-fx
+                 (fn [v] (swap! registered-calls conj v)))
+      (rf/reg-event-fx :dw-test/sync-fire
+                       (fn [_ [_ payload]]
+                         {:dw-test/sync-fx payload}))
+      (rf/dispatch-sync-with [:dw-test/sync-fire :sync-payload]
+                             {:dw-test/sync-fx
+                              (fn [v] (swap! stub-calls conj v))})
+      ;; No promise/deref needed — dispatch-sync-with returns after the
+      ;; handler chain has run synchronously.
+      (is (= [:sync-payload] @stub-calls)
+          "stub received the effect value on the sync path")
+      (is (empty? @registered-calls)
+          "registered handler did not fire on dispatch-sync-with"))))
+
+(deftest dispatch-sync-with-returns-nil
+  (testing "dispatch-sync-with mirrors dispatch-sync's nil return
+            (and dispatch-with mirrors dispatch's nil return) — the
+            return-value contract in dispatch-with's docstring"
+    (rf/reg-event-db :dw-test/return-shape (fn [db _] db))
+    (is (nil? (rf/dispatch-with [:dw-test/return-shape] {})))
+    (is (nil? (rf/dispatch-sync-with [:dw-test/return-shape] {})))))

--- a/test/re_frame/handler_source_meta_test.clj
+++ b/test/re_frame/handler_source_meta_test.clj
@@ -60,6 +60,18 @@
     (is (nil? (meta (registrar/get-handler :event :test-meta/plain-fn-path)))
         "no &form available to a defn — no meta on the registered chain")))
 
+(deftest decorate-handler-meta-skips-opaque-handler
+  (testing "-decorate-handler-meta! silently skips a handler value that can't carry metadata"
+    (let [opaque (Object.)]
+      (registrar/register-handler :fx :test-meta/opaque-handler opaque)
+      (is (nil? (registrar/-decorate-handler-meta!
+                 :fx :test-meta/opaque-handler {:file "opaque.clj" :line 1}))
+          "decorate returns nil and does not throw")
+      (is (identical? opaque (registrar/get-handler :fx :test-meta/opaque-handler))
+          "opaque handler remains registered")
+      (is (nil? (meta (registrar/get-handler :fx :test-meta/opaque-handler)))
+          "no metadata was attached"))))
+
 (deftest core-reg-event-fx-fn-form-dispatches
   (testing "calling re-frame.core/reg-event-fx as a function still works"
     (let [seen (atom nil)]

--- a/test/re_frame/handler_source_meta_test.clj
+++ b/test/re_frame/handler_source_meta_test.clj
@@ -259,3 +259,63 @@
             (str form " passes :" (name expected-kind) " as the handler kind"))
         (is (some #(= expected-fn %) flat)
             (str form " delegates to " expected-fn))))))
+
+;; -- form-meta :file regression -----------------------------------------------
+;;
+;; Pins the contract that `:file` is sourced from `(meta &form)` first —
+;; the reader attaches `{:file :line}` to the form being read; in CLJS
+;; under shadow-cljs `(:file &env)` is not populated and `*file*` is the
+;; placeholder `"NO_SOURCE_PATH"`, so a macro that only reaches for those
+;; two emits a useless `:file` value at every consumer call site. Pattern
+;; mirrors `re-com.core/at`, which has captured CLJS call-site file/line
+;; this way for years.
+;;
+;; CLJ test runner can exercise the same path by macroexpand-1'ing a
+;; form with explicit reader-style `:file :line` metadata and walking
+;; the expansion for the `:re-frame/source` map literal.
+
+(defn- find-source-meta-map
+  "Walk an expanded macro form looking for the literal map carrying
+   `:file` and `:line` (the captured src-meta argument to
+   `-decorate-handler-meta!` / `vary-meta`)."
+  [expanded]
+  (some #(when (and (map? %)
+                    (contains? % :file)
+                    (contains? % :line))
+           %)
+        (tree-seq coll? seq expanded)))
+
+(deftest macros-source-meta-prefers-form-meta-over-star-file
+  (testing "form-meta :file wins over (:file &env) and *file* — required
+            for CLJS under shadow-cljs where the latter two are useless"
+    (doseq [form ['(re-frame.macros/reg-event-db :test-meta/site (fn [d _] d))
+                  '(re-frame.macros/reg-event-fx :test-meta/site (fn [_ _] {}))
+                  '(re-frame.macros/reg-event-ctx :test-meta/site identity)
+                  '(re-frame.macros/reg-sub       :test-meta/site (fn [d _] d))
+                  '(re-frame.macros/reg-fx        :test-meta/site (fn [_] nil))
+                  '(re-frame.macros/dispatch      [:test-meta/site])
+                  '(re-frame.macros/dispatch-sync [:test-meta/site])
+                  '(re-frame.macros/subscribe     [:test-meta/site])]]
+      (let [tagged   (with-meta form {:file "src/app/synthetic.cljs" :line 99})
+            expanded (macroexpand-1 tagged)
+            src-meta (find-source-meta-map expanded)]
+        (is (some? src-meta)
+            (str form " expands to a form containing the :re-frame/source map literal"))
+        (is (= "src/app/synthetic.cljs" (:file src-meta))
+            (str form " captures :file from form-meta, NOT *file*"))
+        (is (= 99 (:line src-meta))
+            (str form " captures :line from form-meta")))))
+
+  (testing "form-meta drives the emitted literal for every source-meta macro"
+    (let [files (->> ['(re-frame.macros/reg-event-db :test-meta/a (fn [d _] d))
+                      '(re-frame.macros/reg-event-db :test-meta/b (fn [d _] d))]
+                     (map-indexed
+                      (fn [i form]
+                        (-> form
+                            (with-meta {:file (str "src/app/site" i ".cljs")
+                                        :line (+ 40 i)})
+                            macroexpand-1
+                            find-source-meta-map
+                            :file))))]
+      (is (= ["src/app/site0.cljs" "src/app/site1.cljs"] files)
+          "macroexpansion embeds the file from each individual form's metadata"))))

--- a/test/re_frame/handler_source_meta_test.cljs
+++ b/test/re_frame/handler_source_meta_test.cljs
@@ -1,0 +1,158 @@
+(ns re-frame.handler-source-meta-test
+  "CLJS coverage for source metadata on the re-frame.macros reg-* API."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.db :as db]
+            [re-frame.interop :as interop]
+            [re-frame.macros :as rf.m]
+            [re-frame.registrar :as registrar]))
+
+(defn fixture-re-frame
+  []
+  (let [restore-re-frame (atom nil)]
+    {:before #(reset! restore-re-frame (rf/make-restore-fn))
+     :after  #(when-let [restore @restore-re-frame]
+                (restore))}))
+
+(use-fixtures :each (fixture-re-frame))
+
+(deftest core-reg-stars-are-functions
+  (testing "re-frame.core registration entry points remain value-position-safe functions"
+    (is (fn? rf/reg-event-db))
+    (is (fn? rf/reg-event-fx))
+    (is (fn? rf/reg-event-ctx))
+    (is (fn? rf/reg-sub))
+    (is (fn? rf/reg-fx))))
+
+(deftest core-reg-event-db-attaches-no-source-meta
+  (testing "the function form does not capture call-site metadata"
+    (rf/reg-event-db :test-meta/plain-fn-path (fn [d _] d))
+    (is (nil? (meta (registrar/get-handler :event :test-meta/plain-fn-path)))
+        "no &form is available to a defn, so no source metadata is attached")))
+
+(deftest core-reg-stars-work-in-value-position
+  (testing "apply and map over re-frame.core reg-* fns still work in CLJS"
+    (let [recorded (atom {})]
+      (apply rf/reg-event-fx
+             [:test-meta/applied
+              (fn [_ [_ tag]]
+                (swap! recorded assoc :applied tag)
+                {})])
+      (dorun (map rf/reg-sub
+                  [:test-meta/m1 :test-meta/m2 :test-meta/m3]
+                  [(fn [d _] (:a d))
+                   (fn [d _] (:b d))
+                   (fn [d _] (:c d))]))
+      (reset! db/app-db {:a 1 :b 2 :c 3})
+      (rf/dispatch-sync [:test-meta/applied :ok])
+      (is (= :ok (:applied @recorded))
+          "apply registers a handler that responds to dispatch-sync")
+      (is (= [1 2 3]
+             [@(rf/subscribe [:test-meta/m1])
+              @(rf/subscribe [:test-meta/m2])
+              @(rf/subscribe [:test-meta/m3])])
+          "map registers each subscription id with its computation function"))))
+
+(deftest macros-reg-event-db-attaches-source-meta
+  (testing "re-frame.macros/reg-event-db attaches source metadata to the registered event chain"
+    (with-redefs [interop/debug-enabled? true]
+      (rf.m/reg-event-db :test-meta/db-handler (fn [d _] d)))
+    (let [m (meta (registrar/get-handler :event :test-meta/db-handler))]
+      (is (some? m)
+          "registered handler carries metadata")
+      (is (string? (:file m))
+          ":file is a string from the CLJS macro expansion environment")
+      (is (re-find #"handler_source_meta_test\.cljs$" (:file m))
+          ":file points at this test file")
+      (is (pos-int? (:line m))
+          ":line is a positive int from (:line (meta &form))"))))
+
+(deftest macros-reg-event-fx-attaches-source-meta
+  (testing "re-frame.macros/reg-event-fx attaches source metadata"
+    (with-redefs [interop/debug-enabled? true]
+      (rf.m/reg-event-fx :test-meta/fx-handler (fn [_ _] {})))
+    (let [m (meta (registrar/get-handler :event :test-meta/fx-handler))]
+      (is (some? m))
+      (is (re-find #"handler_source_meta_test\.cljs$" (:file m)))
+      (is (pos-int? (:line m))))))
+
+(deftest macros-reg-event-ctx-attaches-source-meta
+  (testing "re-frame.macros/reg-event-ctx attaches source metadata"
+    (with-redefs [interop/debug-enabled? true]
+      (rf.m/reg-event-ctx :test-meta/ctx-handler identity))
+    (let [m (meta (registrar/get-handler :event :test-meta/ctx-handler))]
+      (is (some? m))
+      (is (re-find #"handler_source_meta_test\.cljs$" (:file m)))
+      (is (pos-int? (:line m))))))
+
+(deftest macros-reg-sub-attaches-source-meta
+  (testing "re-frame.macros/reg-sub attaches source metadata"
+    (with-redefs [interop/debug-enabled? true]
+      (rf.m/reg-sub :test-meta/sub-handler (fn [d _] (:n d))))
+    (let [m (meta (registrar/get-handler :sub :test-meta/sub-handler))]
+      (is (some? m))
+      (is (re-find #"handler_source_meta_test\.cljs$" (:file m)))
+      (is (pos-int? (:line m))))))
+
+(deftest macros-reg-fx-attaches-source-meta
+  (testing "re-frame.macros/reg-fx attaches source metadata"
+    (with-redefs [interop/debug-enabled? true]
+      (rf.m/reg-fx :test-meta/fx-effect (fn [_] nil)))
+    (let [m (meta (registrar/get-handler :fx :test-meta/fx-effect))]
+      (is (some? m))
+      (is (re-find #"handler_source_meta_test\.cljs$" (:file m)))
+      (is (pos-int? (:line m))))))
+
+(deftest macros-different-call-sites-have-different-line-numbers
+  (testing "two re-frame.macros/reg-event-db calls get distinct line metadata"
+    (with-redefs [interop/debug-enabled? true]
+      (rf.m/reg-event-db :test-meta/site-a (fn [d _] d))
+      (rf.m/reg-event-db :test-meta/site-b (fn [d _] d)))
+    (let [a (:line (meta (registrar/get-handler :event :test-meta/site-a)))
+          b (:line (meta (registrar/get-handler :event :test-meta/site-b)))]
+      (is (pos-int? a))
+      (is (pos-int? b))
+      (is (not= a b)
+          "macros capture the concrete CLJS call-site line"))))
+
+(deftest macros-reg-event-db-with-interceptors-attaches-meta
+  (testing "the 3-ary form also captures source metadata"
+    (with-redefs [interop/debug-enabled? true]
+      (rf.m/reg-event-db :test-meta/with-interceptors []
+                         (fn [d _] d)))
+    (let [m (meta (registrar/get-handler :event :test-meta/with-interceptors))]
+      (is (some? m))
+      (is (string? (:file m))))))
+
+(deftest macros-reg-sub-with-sugar-pair-still-meta
+  (testing "the variadic :<- sugar form composes and source metadata lands on the derived sub"
+    (with-redefs [interop/debug-enabled? true]
+      (rf.m/reg-sub :test-meta/sugared-leaf (fn [d _] (:n d)))
+      (rf.m/reg-sub :test-meta/sugared-derived
+                    :<- [:test-meta/sugared-leaf]
+                    (fn [n _] (* 2 n))))
+    (reset! db/app-db {:n 21})
+    (is (= 42 @(rf/subscribe [:test-meta/sugared-derived]))
+        ":<- sugar pair routes the upstream sub's value to the computation fn")
+    (let [m (meta (registrar/get-handler :sub :test-meta/sugared-derived))]
+      (is (some? m))
+      (is (re-find #"handler_source_meta_test\.cljs$" (:file m))))))
+
+(deftest production-branch-does-not-decorate-handler-meta
+  (testing "with debug disabled, the macro registers via core without decorating metadata"
+    (with-redefs [interop/debug-enabled? false]
+      (rf.m/reg-event-db :test-meta/prod-handler (fn [d _] d)))
+    (is (nil? (meta (registrar/get-handler :event :test-meta/prod-handler)))
+        "production branch does not call -decorate-handler-meta!")))
+
+(deftest decorate-handler-meta-skips-opaque-handler
+  (testing "-decorate-handler-meta! silently skips a handler value that cannot carry metadata"
+    (let [opaque #js {}]
+      (registrar/register-handler :fx :test-meta/opaque-handler opaque)
+      (is (nil? (registrar/-decorate-handler-meta!
+                 :fx :test-meta/opaque-handler {:file "opaque.cljs" :line 1}))
+          "decorate returns nil and does not throw")
+      (is (identical? opaque (registrar/get-handler :fx :test-meta/opaque-handler))
+          "opaque handler remains registered")
+      (is (nil? (meta (registrar/get-handler :fx :test-meta/opaque-handler)))
+          "no metadata was attached"))))

--- a/test/re_frame/interop_test.clj
+++ b/test/re_frame/interop_test.clj
@@ -1,0 +1,11 @@
+(ns re-frame.interop-test
+  "JVM-only coverage for the Clojure implementations in
+   `re-frame.interop`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.interop :as interop]))
+
+(deftest next-tick-runs-on-daemon-thread
+  (testing "next-tick does not keep JVM test processes alive after tests finish"
+    (let [result (promise)]
+      (interop/next-tick #(deliver result (.isDaemon (Thread/currentThread))))
+      (is (true? (deref result 1000 ::timeout))))))

--- a/test/re_frame/query_v_for_reaction_test.cljs
+++ b/test/re_frame/query_v_for_reaction_test.cljs
@@ -1,0 +1,111 @@
+(ns re-frame.query-v-for-reaction-test
+  "CLJS coverage for re-frame.core/query-v-for-reaction. These tests
+   exercise the platform where reagent ids are distinct, so the reverse
+   map must be keyed by the reaction object itself."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.db :as db]
+            [re-frame.interop :as interop]
+            [re-frame.subs :as subs]
+            [re-frame.trace :as trace]))
+
+(defn fixture-re-frame
+  []
+  (let [restore-re-frame (atom nil)
+        trace-before     (atom nil)]
+    {:before #(do
+                (reset! restore-re-frame (rf/make-restore-fn))
+                (reset! trace-before trace/trace-enabled?)
+                (set! trace/trace-enabled? false))
+     :after  #(do
+                (set! trace/trace-enabled? @trace-before)
+                (when-let [restore @restore-re-frame]
+                  (restore)))}))
+
+(use-fixtures :each (fixture-re-frame))
+
+(deftest returns-query-v-for-known-reaction
+  (testing "subscribe creates a reaction; query-v-for-reaction returns its query-v"
+    (rf/reg-sub :qvfr/echo (fn [d [_ x]] [(:n d) x]))
+    (reset! db/app-db {:n 1})
+    (let [r (rf/subscribe [:qvfr/echo 42])]
+      (is (some? r) "subscribe returned a reaction")
+      (is (= [:qvfr/echo 42] (rf/query-v-for-reaction r))
+          "lookup returns the exact query-v passed to subscribe"))))
+
+(deftest distinct-reactions-have-distinct-query-vs-and-reagent-ids
+  (testing "distinct CLJS reactions map back to their own query-vs"
+    (rf/reg-sub :qvfr/echo (fn [d [_ x]] [(:n d) x]))
+    (reset! db/app-db {:n 1})
+    (let [r1 (rf/subscribe [:qvfr/echo :a])
+          r2 (rf/subscribe [:qvfr/echo :b])]
+      (is (not (identical? r1 r2))
+          "different params produce different reactions")
+      (is (not= (interop/reagent-id r1)
+                (interop/reagent-id r2))
+          "CLJS reagent ids remain distinct for these reactions")
+      (is (= [:qvfr/echo :a] (rf/query-v-for-reaction r1)))
+      (is (= [:qvfr/echo :b] (rf/query-v-for-reaction r2))))))
+
+(deftest cached-resubscribe-returns-same-query-v
+  (testing "the cache returns the same reaction on a second subscribe; lookup is stable"
+    (rf/reg-sub :qvfr/echo (fn [d [_ x]] [(:n d) x]))
+    (reset! db/app-db {:n 1})
+    (let [r1 (rf/subscribe [:qvfr/echo :same])
+          r2 (rf/subscribe [:qvfr/echo :same])]
+      (is (identical? r1 r2)
+          "subscription cache returns the same reaction")
+      (is (= [:qvfr/echo :same] (rf/query-v-for-reaction r1))))))
+
+(deftest unknown-reaction-returns-nil
+  (testing "a reaction not produced by subscribe returns nil"
+    (let [bare (interop/make-reaction (fn [] :not-a-sub))]
+      (is (nil? (rf/query-v-for-reaction bare))
+          "object never registered with the subs cache -> nil")
+      (interop/dispose! bare))))
+
+(deftest disposed-reaction-drops-from-reverse-map
+  (testing "after clear-subscription-cache!, the reaction's entry is gone"
+    (rf/reg-sub :qvfr/echo (fn [d _] (:n d)))
+    (reset! db/app-db {:n 7})
+    (let [r (rf/subscribe [:qvfr/echo])]
+      (is (= [:qvfr/echo] (rf/query-v-for-reaction r))
+          "registered before clear")
+      (rf/clear-subscription-cache!)
+      (is (nil? (rf/query-v-for-reaction r))
+          "dispose callback removed the reverse-map entry"))))
+
+(deftest subs-namespace-fn-matches-core-export
+  (testing "the re-export in re-frame.core delegates to re-frame.subs unchanged"
+    (rf/reg-sub :qvfr/echo (fn [d _] (:n d)))
+    (reset! db/app-db {:n 1})
+    (let [r (rf/subscribe [:qvfr/echo])]
+      (is (= (rf/query-v-for-reaction r)
+             (subs/query-v-for-reaction r))
+          "core re-export and subs fn agree"))))
+
+(deftest production-mode-skips-reverse-map-write-when-tracing-is-disabled
+  (testing "debug false and tracing false skip the reaction->query-v write"
+    (rf/reg-sub :qvfr/echo (fn [d _] (:n d)))
+    (reset! db/app-db {:n 1})
+    (set! trace/trace-enabled? false)
+    (with-redefs [interop/debug-enabled? false]
+      (let [r (rf/subscribe [:qvfr/echo])]
+        (is (nil? (rf/query-v-for-reaction r))
+            "production mode with tracing off does not populate the reverse map")))
+    (rf/clear-subscription-cache!)
+    (let [r (rf/subscribe [:qvfr/echo])]
+      (is (= [:qvfr/echo] (rf/query-v-for-reaction r))
+          "debug on populates the reverse map again"))))
+
+(deftest dispose-cleans-up-reverse-map-even-when-debug-flips-off
+  (testing "dispose-side cleanup is unconditional"
+    (rf/reg-sub :qvfr/echo (fn [d _] (:n d)))
+    (reset! db/app-db {:n 1})
+    (let [r (rf/subscribe [:qvfr/echo])]
+      (is (= [:qvfr/echo] (rf/query-v-for-reaction r))
+          "subscribed under debug-enabled? true -> entry present")
+      (with-redefs [interop/debug-enabled? false]
+        (rf/clear-subscription-cache!))
+      (is (nil? (rf/query-v-for-reaction r))
+          "clear-subscription-cache! invoked dispose and removed the entry"))))

--- a/test/re_frame/router_test.clj
+++ b/test/re_frame/router_test.clj
@@ -1,7 +1,9 @@
 (ns re-frame.router-test
   (:require [clojure.test :refer :all]
             [re-frame.core :as rf]
-            [re-frame.db :as db]))
+            [re-frame.db :as db]
+            [re-frame.events :as events]
+            [re-frame.router :as router]))
 
 (defn fixture-re-frame
   [f]
@@ -58,3 +60,20 @@
       (is (true? (::child-ran? @db/app-db)))
       (finally
         (rf/remove-post-event-callback cb-key)))))
+
+(deftest dispatch-metadata-tagging-is-best-effort
+  (testing "parent dispatch ids are attached when the event supports metadata"
+    (let [event [::child]]
+      (binding [events/*current-dispatch-id* ::parent-id]
+        (is (= ::parent-id
+               (-> (#'router/tag-with-parent-dispatch-id event)
+                   meta
+                   :re-frame/parent-dispatch-id))))))
+
+  (testing "non-IObj event values pass through instead of crashing"
+    (binding [events/*current-dispatch-id* ::parent-id
+              events/*handling* (vary-meta [::parent] assoc
+                                           :re-frame/fx-overrides
+                                           {::fx identity})]
+      (is (= ::opaque (#'router/tag-with-parent-dispatch-id ::opaque)))
+      (is (= ::opaque (#'router/tag-with-fx-overrides ::opaque))))))

--- a/test/re_frame/subscribe_source_meta_test.clj
+++ b/test/re_frame/subscribe_source_meta_test.clj
@@ -50,6 +50,17 @@
       (is (= 1 (count (filter #(= '(build-query) %) flat)))
           "subscribe expansion contains the user query expression once"))))
 
+(deftest subscribe-macroexpand-supports-dynv-arity
+  (testing "(rf.m/subscribe query-v dynv) targets the two-arity core subscribe call"
+    (let [expanded (macroexpand-1 '(re-frame.macros/subscribe [:foo] [dyn]))
+          flat     (tree-seq coll? seq expanded)]
+      (is (some #(= 're-frame.core/subscribe %) flat)
+          "expanded form targets re-frame.core/subscribe")
+      (is (some #(= '[dyn] %) flat)
+          "expanded form passes dynv through")
+      (is (some #(= :re-frame/source %) flat)
+          "expanded form still attaches source metadata to query-v"))))
+
 (deftest subscribe-attaches-source-meta-on-query-v
   (testing "rf.m/subscribe attaches {:file :line} as :re-frame/source on the query-v stored against the reaction"
     (rf/reg-sub :sub-test/echo (fn [db _] (:val db)))
@@ -68,6 +79,19 @@
           ":file points at this test file")
       (is (pos-int? (-> m :re-frame/source :line))
           ":line is a positive int from (:line (meta &form))"))))
+
+(deftest subscribe-dynv-arity-attaches-source-meta-on-query-v
+  (testing "rf.m/subscribe mirrors core's [query-v dynv] arity while meta-tagging query-v"
+    (rf/reg-sub :sub-test/dyn (fn [_db _ dynv] (first dynv)))
+    (let [dyn-arg (atom 42)
+          r       (rf.m/subscribe [:sub-test/dyn] [dyn-arg])
+          qv      (subs/query-v-for-reaction r)
+          m       (meta qv)]
+      (is (= 42 @r)
+          "dynv is passed through to re-frame.core/subscribe")
+      (is (= [:sub-test/dyn] qv))
+      (is (some? (:re-frame/source m))
+          "source metadata is attached to query-v for the dynv arity"))))
 
 (deftest subscribe-different-call-sites-have-different-line-numbers
   (testing "two adjacent rf.m/subscribe calls (different sub-ids to avoid cache reuse) capture distinct :line meta"

--- a/test/re_frame/subscribe_source_meta_test.cljs
+++ b/test/re_frame/subscribe_source_meta_test.cljs
@@ -1,0 +1,101 @@
+(ns re-frame.subscribe-source-meta-test
+  "CLJS coverage for re-frame.macros/subscribe source metadata and the
+   production no-op branch."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.db :as db]
+            [re-frame.interop :as interop]
+            [re-frame.macros :as rf.m]
+            [re-frame.subs :as subs]
+            [re-frame.trace :as trace]))
+
+(defn fixture-re-frame
+  []
+  (let [restore-re-frame (atom nil)
+        trace-before     (atom nil)]
+    {:before #(do
+                (reset! restore-re-frame (rf/make-restore-fn))
+                (reset! trace-before trace/trace-enabled?)
+                (set! trace/trace-enabled? false))
+     :after  #(do
+                (set! trace/trace-enabled? @trace-before)
+                (when-let [restore @restore-re-frame]
+                  (restore)))}))
+
+(use-fixtures :each (fixture-re-frame))
+
+(deftest subscribe-attaches-source-meta-on-query-v
+  (testing "rf.m/subscribe attaches {:file :line} as :re-frame/source in CLJS dev mode"
+    (with-redefs [interop/debug-enabled? true]
+      (rf/reg-sub :sub-test/echo (fn [d _] (:val d)))
+      (reset! db/app-db {:val 99})
+      (let [r  (rf.m/subscribe [:sub-test/echo])
+            qv (subs/query-v-for-reaction r)
+            m  (meta qv)]
+        (is (some? m)
+            "the query-v stored against the reaction carries metadata")
+        (is (some? (:re-frame/source m))
+            ":re-frame/source is present on the query-v meta")
+        (is (string? (-> m :re-frame/source :file))
+            ":file is a string from the CLJS macro expansion environment")
+        (is (re-find #"subscribe_source_meta_test\.cljs$"
+                     (-> m :re-frame/source :file))
+            ":file points at this test file")
+        (is (pos-int? (-> m :re-frame/source :line))
+            ":line is a positive int from (:line (meta &form))")))))
+
+(deftest subscribe-different-call-sites-have-different-line-numbers
+  (testing "two rf.m/subscribe calls with different query ids capture distinct line metadata"
+    (with-redefs [interop/debug-enabled? true]
+      (rf/reg-sub :sub-test/a (fn [d _] (:a d)))
+      (rf/reg-sub :sub-test/b (fn [d _] (:b d)))
+      (reset! db/app-db {:a 1 :b 2})
+      (let [ra (rf.m/subscribe [:sub-test/a])
+            rb (rf.m/subscribe [:sub-test/b])
+            la (-> ra subs/query-v-for-reaction meta :re-frame/source :line)
+            lb (-> rb subs/query-v-for-reaction meta :re-frame/source :line)]
+        (is (pos-int? la))
+        (is (pos-int? lb))
+        (is (not= la lb)
+            "macros capture the concrete CLJS call-site line")))))
+
+(deftest subscribe-preserves-user-supplied-query-v-meta
+  (testing "user-supplied query-v metadata survives the macro's vary-meta call"
+    (with-redefs [interop/debug-enabled? true]
+      (rf/reg-sub :sub-test/echo (fn [d _] (:val d)))
+      (reset! db/app-db {:val 1})
+      (let [r  (rf.m/subscribe ^:my-flag [:sub-test/echo])
+            qv (subs/query-v-for-reaction r)
+            m  (meta qv)]
+        (is (some? (:re-frame/source m))
+            "macro-added :re-frame/source is present")
+        (is (true? (:my-flag m))
+            "user-supplied :my-flag survives the vary-meta merge")))))
+
+(deftest subscribe-cache-key-ignores-meta
+  (testing "a meta'd query-v and a bare query-v resolve to the same cached reaction"
+    (with-redefs [interop/debug-enabled? true]
+      (rf/reg-sub :sub-test/echo (fn [d _] (:val d)))
+      (reset! db/app-db {:val 1})
+      (let [r-meta (rf.m/subscribe [:sub-test/echo])
+            r-bare (rf/subscribe [:sub-test/echo])]
+        (is (identical? r-meta r-bare)
+            "macro-meta'd and bare-call subscribe paths return the same cached reaction")
+        (is (some? (:re-frame/source (meta (subs/query-v-for-reaction r-meta))))
+            "the cached query-v retains :re-frame/source meta from the first caller")))))
+
+(deftest subscribe-production-branch-does-not-add-source-meta
+  (testing "with debug disabled, the macro passes the query-v through without source metadata"
+    (rf/reg-sub :sub-test/prod (fn [d _] (:val d)))
+    (reset! db/app-db {:val 1})
+    (set! trace/trace-enabled? true)
+    (with-redefs [interop/debug-enabled? false]
+      (let [r  (rf.m/subscribe ^:my-flag [:sub-test/prod])
+            qv (subs/query-v-for-reaction r)
+            m  (meta qv)]
+        (is (= [:sub-test/prod] qv)
+            "trace keeps the production query-v visible for inspection")
+        (is (nil? (:re-frame/source m))
+            "production branch does not attach :re-frame/source")
+        (is (true? (:my-flag m))
+            "production branch passes through the user's query-v unchanged")))))

--- a/test/re_frame/subscribe_source_meta_test.cljs
+++ b/test/re_frame/subscribe_source_meta_test.cljs
@@ -44,6 +44,20 @@
         (is (pos-int? (-> m :re-frame/source :line))
             ":line is a positive int from (:line (meta &form))")))))
 
+(deftest subscribe-dynv-arity-attaches-source-meta-on-query-v
+  (testing "rf.m/subscribe supports core's [query-v dynv] arity in CLJS dev mode"
+    (with-redefs [interop/debug-enabled? true]
+      (rf/reg-sub :sub-test/dyn (fn [_ _ dynv] (first dynv)))
+      (let [dyn-arg (atom 42)
+            r       (rf.m/subscribe [:sub-test/dyn] [dyn-arg])
+            qv      (subs/query-v-for-reaction r)
+            m       (meta qv)]
+        (is (= 42 @r)
+            "dynv is passed through to re-frame.core/subscribe")
+        (is (= [:sub-test/dyn] qv))
+        (is (some? (:re-frame/source m))
+            "source metadata is attached to query-v for the dynv arity")))))
+
 (deftest subscribe-different-call-sites-have-different-line-numbers
   (testing "two rf.m/subscribe calls with different query ids capture distinct line metadata"
     (with-redefs [interop/debug-enabled? true]

--- a/test/re_frame/test_runner.cljs
+++ b/test/re_frame/test_runner.cljs
@@ -7,6 +7,10 @@
    [re-frame.subs-test]
    [re-frame.fx-test]
    [re-frame.registrar-test]
+   [re-frame.dispatch-source-meta-test]
+   [re-frame.subscribe-source-meta-test]
+   [re-frame.query-v-for-reaction-test]
+   [re-frame.handler-source-meta-test]
    [re-frame.trace-test]
    [re-frame.restore-test]))
 
@@ -22,5 +26,9 @@
    're-frame.subs-test
    're-frame.fx-test
    're-frame.registrar-test
+   're-frame.dispatch-source-meta-test
+   're-frame.subscribe-source-meta-test
+   're-frame.query-v-for-reaction-test
+   're-frame.handler-source-meta-test
    're-frame.trace-test
    're-frame.restore-test))

--- a/test/re_frame/trace_delivery_test.clj
+++ b/test/re_frame/trace_delivery_test.clj
@@ -439,13 +439,13 @@
       (is (empty? (:cascaded-epochs result))))))
 
 ;; ---------------------------------------------------------------------------
-;; *dispatch-id-capture* — deterministic root-id capture
+;; *on-dispatch-id* — deterministic root-id capture
 ;; ---------------------------------------------------------------------------
 
-(deftest dispatch-id-capture-receives-handle-allocated-id
-  (testing "binding `events/*dispatch-id-capture*` to an atom causes
-            `handle` to reset! that atom with the freshly-allocated
-            dispatch-id BEFORE the trace fires. This is the hook
+(deftest on-dispatch-id-receives-handle-allocated-id
+  (testing "binding `events/*on-dispatch-id*` to a callback causes
+            `handle` to call it with the freshly-allocated dispatch-id
+            BEFORE the trace fires. This is the hook
             dispatch-and-settle uses to identify the root of its
             cascade WITHOUT relying on event-vector equality.
 
@@ -467,7 +467,7 @@
                                                         (= [:capture-test/touch]
                                                            (-> t :tags :event)))]
                                        (swap! seen-tags conj (:tags t)))))
-          (binding [events/*dispatch-id-capture* captured]
+          (binding [events/*on-dispatch-id* #(reset! captured %)]
             (rf/dispatch-sync [:capture-test/touch]))
           (is (uuid? @captured)
               "the captured value is the UUID handle allocated for this dispatch")
@@ -478,7 +478,7 @@
           (testing "two consecutive captures yield distinct ids — proves the hook
                     fires per-dispatch, not once-and-cached"
             (let [captured-2 (atom nil)]
-              (binding [events/*dispatch-id-capture* captured-2]
+              (binding [events/*on-dispatch-id* #(reset! captured-2 %)]
                 (rf/dispatch-sync [:capture-test/touch]))
               (is (uuid? @captured-2))
               (is (not= @captured @captured-2))))

--- a/test/re_frame/trace_delivery_test.clj
+++ b/test/re_frame/trace_delivery_test.clj
@@ -230,6 +230,72 @@
               "the child remains attributed to the dispatch-sync root")
           (is (true? @child-ran?)))))))
 
+(deftest dispatch-and-settle-timeout-result-on-jvm
+  (testing "the overall timeout can win and returns the documented timeout shape"
+    (with-tracing-on
+      (rf/reg-event-db :trace-timeout/slow
+                       (fn [db _]
+                         (Thread/sleep 30)
+                         (assoc db :slow true)))
+      (let [p      (router/dispatch-and-settle [:trace-timeout/slow]
+                                               {:timeout-ms       1
+                                                :settle-window-ms 250})
+            result (deref p 1000 ::timed-out)]
+        (is (not= ::timed-out result))
+        (is (= {:ok? false
+                :reason :timeout
+                :event [:trace-timeout/slow]}
+               (select-keys result [:ok? :reason :event])))
+        (is (vector? (:captured-epochs result)))))))
+
+(deftest dispatch-and-settle-can-omit-cascaded-epochs-on-jvm
+  (testing ":include-cascaded? false elides the cascaded epoch key"
+    (with-tracing-on
+      (rf/reg-event-fx :trace-cascade-filter/parent
+                       (fn [_ _]
+                         {:fx [[:dispatch [:trace-cascade-filter/child]]]}))
+      (rf/reg-event-db :trace-cascade-filter/child
+                       (fn [db _] (assoc db :child true)))
+      (let [p      (router/dispatch-and-settle
+                    [:trace-cascade-filter/parent]
+                    {:timeout-ms        2000
+                     :settle-window-ms  100
+                     :include-cascaded? false})
+            result (deref p 3000 ::timed-out)]
+        (is (not= ::timed-out result))
+        (is (true? (:ok? result)))
+        (is (= [:trace-cascade-filter/parent] (-> result :root-epoch :event)))
+        (is (not (contains? result :cascaded-epochs)))))))
+
+(deftest dispatch-and-settle-captures-multi-level-cascade-on-jvm
+  (testing "descendant events are captured recursively through parent dispatch ids"
+    (with-tracing-on
+      (rf/reg-event-fx :trace-multilevel/parent
+                       (fn [_ _]
+                         {:fx [[:dispatch [:trace-multilevel/child]]]}))
+      (rf/reg-event-fx :trace-multilevel/child
+                       (fn [_ _]
+                         {:fx [[:dispatch [:trace-multilevel/grandchild]]]}))
+      (rf/reg-event-db :trace-multilevel/grandchild
+                       (fn [db _] (assoc db :grandchild true)))
+      (let [p          (router/dispatch-and-settle
+                        [:trace-multilevel/parent]
+                        {:timeout-ms       2000
+                         :settle-window-ms 100})
+            result     (deref p 3000 ::timed-out)
+            cascaded   (:cascaded-epochs result)
+            by-event   (into {} (map (juxt :event identity) cascaded))
+            child      (get by-event [:trace-multilevel/child])
+            grandchild (get by-event [:trace-multilevel/grandchild])]
+        (is (not= ::timed-out result))
+        (is (true? (:ok? result)))
+        (is (= #{[:trace-multilevel/child] [:trace-multilevel/grandchild]}
+               (set (map :event cascaded))))
+        (is (= (-> result :root-epoch :dispatch-id)
+               (:parent-dispatch-id child)))
+        (is (= (:dispatch-id child)
+               (:parent-dispatch-id grandchild)))))))
+
 (deftest dispatch-and-settle-waits-for-declared-fx-dispatch-children-on-jvm
   (testing "trace-on dispatch-and-settle does not resolve from the
             root-only quiet window when the root epoch's effects declare

--- a/test/re_frame/trace_delivery_test.clj
+++ b/test/re_frame/trace_delivery_test.clj
@@ -216,9 +216,9 @@
                            (reset! child-ran? true)
                            db))
         (let [p           (router/dispatch-and-settle [:trace-cascade/parent]
-                                                      {:timeout-ms       2000
-                                                       :settle-window-ms 1000})
-              result      (deref p 3000 ::timed-out)
+                                                      {:timeout-ms       5000
+                                                       :settle-window-ms 250})
+              result      (deref p 6000 ::timed-out)
               root-id     (-> result :root-epoch :dispatch-id)
               child-epoch (first (:cascaded-epochs result))]
           (is (not= ::timed-out result))

--- a/test/re_frame/trace_delivery_test.clj
+++ b/test/re_frame/trace_delivery_test.clj
@@ -486,7 +486,7 @@
             (trace/remove-trace-cb cb-key)))))))
 
 ;; ---------------------------------------------------------------------------
-;; dispatch-and-settle — concurrent same-vector regression (rf-6q6)
+;; dispatch-and-settle — concurrent same-vector regression
 ;; ---------------------------------------------------------------------------
 
 (deftest dispatch-and-settle-distinguishes-concurrent-same-vector

--- a/test/re_frame/trace_delivery_test.clj
+++ b/test/re_frame/trace_delivery_test.clj
@@ -384,6 +384,17 @@
       (is (nil? (rf/dispatch-sync-with [:core-public/override-smoke] {}))
           "dispatch-sync-with is callable through re-frame.core and matches dispatch-sync's nil return"))))
 
+(deftest core-tracing-re-exports-match-source-of-truth
+  (testing "the public tracing APIs are reachable from re-frame.core"
+    (is (= trace/tag-schema rf/tag-schema))
+    (is (identical? trace/validate-trace? rf/validate-trace?))
+    (is (identical? trace/set-validate-trace! rf/set-validate-trace!))
+    (is (identical? trace/register-trace-cb rf/register-trace-cb))
+    (is (identical? trace/remove-trace-cb rf/remove-trace-cb))
+    (is (identical? trace/register-epoch-cb rf/register-epoch-cb))
+    (is (identical? trace/remove-epoch-cb rf/remove-epoch-cb))
+    (is (identical? trace/assemble-epochs rf/assemble-epochs))))
+
 ;; ---------------------------------------------------------------------------
 ;; re-frame.alpha public re-exports
 ;; ---------------------------------------------------------------------------

--- a/test/re_frame/trace_delivery_test.clj
+++ b/test/re_frame/trace_delivery_test.clj
@@ -122,6 +122,60 @@
             (trace/remove-epoch-cb cb-key)))))))
 
 ;; ---------------------------------------------------------------------------
+;; :input-query-vs — subscription input provenance
+;; ---------------------------------------------------------------------------
+
+(defn- capture-traces [f]
+  (let [received (atom [])
+        cb-key   (UUID/randomUUID)]
+    (try
+      (trace/register-trace-cb cb-key (fn [batch] (swap! received into batch)))
+      (f)
+      @received
+      (finally
+        (trace/remove-trace-cb cb-key)))))
+
+(deftest sub-run-trace-emits-input-query-vs
+  (testing "a single-input subscription emits the input subscription query-v"
+    (with-tracing-on
+      (rf/reg-sub :input-qvs/leaf (fn [db _] (:leaf db)))
+      (rf/reg-sub :input-qvs/derived
+                  (fn [_ _] (rf/subscribe [:input-qvs/leaf]))
+                  (fn [leaf _] leaf))
+      (let [traces  (capture-traces #(deref (rf/subscribe [:input-qvs/derived])))
+            sub-run (first (filter #(and (= :sub/run (:op-type %))
+                                         (= [:input-qvs/derived]
+                                            (-> % :tags :query-v)))
+                                   traces))]
+        (is (= [[:input-qvs/leaf]]
+               (-> sub-run :tags :input-query-vs)))
+        (is (= (count (-> sub-run :tags :input-signals))
+               (count (-> sub-run :tags :input-query-vs)))
+            ":input-query-vs stays aligned with :input-signals"))))
+
+  (testing "multi-input subscriptions preserve input order"
+    (with-tracing-on
+      (rf/reg-sub :input-qvs/a (fn [db _] (:a db)))
+      (rf/reg-sub :input-qvs/b (fn [db _] (:b db)))
+      (rf/reg-sub :input-qvs/c (fn [db _] (:c db)))
+      (rf/reg-sub :input-qvs/multi
+                  (fn [_ _]
+                    [(rf/subscribe [:input-qvs/a])
+                     (rf/subscribe [:input-qvs/b])
+                     (rf/subscribe [:input-qvs/c])])
+                  (fn [values _] values))
+      (let [traces  (capture-traces #(deref (rf/subscribe [:input-qvs/multi])))
+            sub-run (first (filter #(and (= :sub/run (:op-type %))
+                                         (= [:input-qvs/multi]
+                                            (-> % :tags :query-v)))
+                                   traces))]
+        (is (= [[:input-qvs/a] [:input-qvs/b] [:input-qvs/c]]
+               (-> sub-run :tags :input-query-vs)))
+        (is (= (count (-> sub-run :tags :input-signals))
+               (count (-> sub-run :tags :input-query-vs)))
+            ":input-query-vs stays aligned with :input-signals")))))
+
+;; ---------------------------------------------------------------------------
 ;; dispatch-and-settle — end-to-end {:ok? true} branch on JVM
 ;; ---------------------------------------------------------------------------
 

--- a/test/re_frame/trace_test.cljs
+++ b/test/re_frame/trace_test.cljs
@@ -293,6 +293,8 @@
                     :dispatch-settle/par-two
                     :dispatch-settle/chi-a
                     :dispatch-settle/chi-b
+                    :dispatch-settle/override-root
+                    :dispatch-settle/override-child
                     :dispatch-settle/par-filter
                     :dispatch-settle/chi-filter
                     :dispatch-settle/other]]
@@ -396,6 +398,51 @@
                       (clear-dispatch-and-settle-events!)
                       (set! trace/trace-enabled? false)
                       (done))))))))
+
+(deftest dispatch-and-settle-applies-fx-overrides
+  (testing "dispatch-and-settle can override fx handlers for the root and its cascade"
+    (async done
+      (let [seen     (atom [])
+            fx-id    :dispatch-settle/spy-fx
+            cleanup! (fn []
+                       (clear-dispatch-and-settle-events!)
+                       (rf/clear-fx fx-id)
+                       (set! trace/trace-enabled? false))]
+        (clear-dispatch-and-settle-events!)
+        (set! trace/trace-enabled? true)
+        (rf/reg-fx fx-id
+                   (fn [value]
+                     (swap! seen conj [:registered value])))
+        (rf/reg-event-fx :dispatch-settle/override-root
+                         (fn [_ _]
+                           {:fx [[fx-id :root]
+                                 [:dispatch [:dispatch-settle/override-child]]]}))
+        (rf/reg-event-fx :dispatch-settle/override-child
+                         (fn [_ _]
+                           {fx-id :child}))
+        (-> (rf/dispatch-and-settle
+             [:dispatch-settle/override-root]
+             {:timeout-ms       1000
+              :settle-window-ms delivery-wait-ms
+              :overrides        {fx-id (fn [value]
+                                         (swap! seen conj [:override value]))}})
+            (.then
+             (fn [raw]
+               (let [result          (js-settle-result->clj raw)
+                     cascaded-events (set (map :event (:cascaded-epochs result)))]
+                 (is (true? (:ok? result)))
+                 (is (= ["override-root"] (-> result :root-epoch :event)))
+                 (is (= #{["override-child"]} cascaded-events)
+                     "the child event is still captured as part of the settled cascade")
+                 (is (= [[:override :root] [:override :child]] @seen)
+                     "the override handles root and cascaded fx; the registered handler is bypassed"))
+               (cleanup!)
+               (done)))
+            (.catch
+             (fn [err]
+               (is false (str "dispatch-and-settle-applies-fx-overrides failed: " err))
+               (cleanup!)
+               (done))))))))
 
 (deftest register-epoch-cb-warns-when-tracing-disabled
   (testing "register-epoch-cb warns instead of registering when tracing is disabled"

--- a/test/re_frame/trace_test.cljs
+++ b/test/re_frame/trace_test.cljs
@@ -108,7 +108,7 @@
       (is (= {} (:app-db/before e)))
       (is (= {:n 1} (:app-db/after e)))
       (is (= [{:id :coeffects} {:id :db-handler}] (:interceptors e))
-          "Q2 default — interceptor records, not just ids"))))
+          "interceptor records, not just ids"))))
 
 (deftest assemble-epochs-event-original-divergence
   (testing ":event/original surfaces on the epoch independently of :event —

--- a/test/re_frame/trace_test.cljs
+++ b/test/re_frame/trace_test.cljs
@@ -284,9 +284,6 @@
                (done))))
          delivery-wait-ms)))))
 
-(defn- js-settle-result->clj [raw]
-  (js->clj raw :keywordize-keys true))
-
 (defn- clear-dispatch-and-settle-events! []
   (doseq [event-id [:dispatch-settle/par
                     :dispatch-settle/chi
@@ -323,16 +320,17 @@
                 (is (fn? (.-then p))
                     "the returned JS Promise exposes .then")
                 (.then p
-                       (fn [raw]
-                         (let [result   (js-settle-result->clj raw)
-                               root     (:root-epoch result)
+                       (fn [result]
+                         (is (map? result)
+                             "CLJS resolves to a Clojure map (no js->clj needed)")
+                         (let [root     (:root-epoch result)
                                cascaded (:cascaded-epochs result)
                                child    (first cascaded)]
                            (is (true? (:ok? result)))
-                           (is (= ["par"] (:event root))
-                               "keyword-fn converted the event keyword to its name")
+                           (is (= [:dispatch-settle/par] (:event root))
+                               "the resolved map preserves the original keyword event vector")
                            (is (= 1 (count cascaded)))
-                           (is (= ["chi"] (:event child)))
+                           (is (= [:dispatch-settle/chi] (:event child)))
                            (is (= (:dispatch-id root) (:parent-dispatch-id child))
                                "the child epoch is attributed to the root dispatch-id"))
                          (clear-dispatch-and-settle-events!)))))
@@ -350,13 +348,12 @@
               (rf/reg-event-db :dispatch-settle/chi-b
                                (fn [db _] (assoc db :chi-b true)))
               (.then (router/dispatch-and-settle [:dispatch-settle/par-two] opts)
-                     (fn [raw]
-                       (let [result   (js-settle-result->clj raw)
-                             root     (:root-epoch result)
+                     (fn [result]
+                       (let [root     (:root-epoch result)
                              cascaded (:cascaded-epochs result)]
                          (is (true? (:ok? result)))
-                         (is (= ["par-two"] (:event root)))
-                         (is (= #{["chi-a"] ["chi-b"]}
+                         (is (= [:dispatch-settle/par-two] (:event root)))
+                         (is (= #{[:dispatch-settle/chi-a] [:dispatch-settle/chi-b]}
                                 (set (map :event cascaded))))
                          (is (every? #(= (:dispatch-id root) (:parent-dispatch-id %))
                                      cascaded)
@@ -377,14 +374,13 @@
               (let [p (router/dispatch-and-settle [:dispatch-settle/par-filter] opts)]
                 (rf/dispatch [:dispatch-settle/other])
                 (.then p
-                       (fn [raw]
-                         (let [result          (js-settle-result->clj raw)
-                               cascaded-events (set (map :event (:cascaded-epochs result)))]
+                       (fn [result]
+                         (let [cascaded-events (set (map :event (:cascaded-epochs result)))]
                            (is (true? (:ok? result)))
-                           (is (= ["par-filter"] (-> result :root-epoch :event)))
-                           (is (= #{["chi-filter"]} cascaded-events)
+                           (is (= [:dispatch-settle/par-filter] (-> result :root-epoch :event)))
+                           (is (= #{[:dispatch-settle/chi-filter]} cascaded-events)
                                "only the child with matching parent-dispatch-id is reported")
-                           (is (not (contains? cascaded-events ["other"]))
+                           (is (not (contains? cascaded-events [:dispatch-settle/other]))
                                "unrelated in-flight dispatch is excluded from cascaded-epochs"))
                          (clear-dispatch-and-settle-events!)))))]
         (-> (single-level)
@@ -427,12 +423,11 @@
               :overrides        {fx-id (fn [value]
                                          (swap! seen conj [:override value]))}})
             (.then
-             (fn [raw]
-               (let [result          (js-settle-result->clj raw)
-                     cascaded-events (set (map :event (:cascaded-epochs result)))]
+             (fn [result]
+               (let [cascaded-events (set (map :event (:cascaded-epochs result)))]
                  (is (true? (:ok? result)))
-                 (is (= ["override-root"] (-> result :root-epoch :event)))
-                 (is (= #{["override-child"]} cascaded-events)
+                 (is (= [:dispatch-settle/override-root] (-> result :root-epoch :event)))
+                 (is (= #{[:dispatch-settle/override-child]} cascaded-events)
                      "the child event is still captured as part of the settled cascade")
                  (is (= [[:override :root] [:override :child]] @seen)
                      "the override handles root and cascaded fx; the registered handler is bypassed"))
@@ -442,6 +437,39 @@
              (fn [err]
                (is false (str "dispatch-and-settle-applies-fx-overrides failed: " err))
                (cleanup!)
+               (done))))))))
+
+(deftest dispatch-and-settle-resolves-with-clojure-data
+  (testing "the CLJS Promise resolves to a Clojure map — namespaced
+            keywords (event keys, :app-db/before, :event/original)
+            survive the resolve without going through clj->js"
+    (async done
+      (let [opts {:timeout-ms 1000 :settle-window-ms delivery-wait-ms}]
+        (clear-dispatch-and-settle-events!)
+        (set! trace/trace-enabled? true)
+        (rf/reg-event-db :dispatch-settle/par
+                         (fn [db _] (assoc db :touched true)))
+        (-> (router/dispatch-and-settle [:dispatch-settle/par] opts)
+            (.then
+             (fn [result]
+               (is (map? result)
+                   "the resolved value is a Clojure map, not a JS object")
+               (is (true? (:ok? result))
+                   ":ok? is the Clojure boolean — keyword key survived")
+               (is (= [:dispatch-settle/par]
+                      (get-in result [:root-epoch :event]))
+                   "the namespaced event keyword is preserved end-to-end")
+               (is (some? (get-in result [:root-epoch :app-db/before]))
+                   "namespaced keys like :app-db/before resolve, not collide
+                    with :event/before under (clj->js v :keyword-fn name)")
+               (clear-dispatch-and-settle-events!)
+               (set! trace/trace-enabled? false)
+               (done)))
+            (.catch
+             (fn [err]
+               (is false (str "dispatch-and-settle-resolves-with-clojure-data failed: " err))
+               (clear-dispatch-and-settle-events!)
+               (set! trace/trace-enabled? false)
                (done))))))))
 
 (deftest register-epoch-cb-warns-when-tracing-disabled

--- a/test/re_frame/trace_zero_cost_test.clj
+++ b/test/re_frame/trace_zero_cost_test.clj
@@ -10,7 +10,7 @@
    fire on every user action, so even a few microseconds per call shows
    up under profiling.
 
-   Strategy: redefine the per-call work (`new-dispatch-id`, `to-seq`)
+   Strategy: redefine the per-call work (`new-uuid`, `to-seq`)
    to counter functions, exercise the hot path with `trace-enabled?`
    in both states, and assert the call count is 0 when off."
   (:require [clojure.test    :refer [deftest is testing use-fixtures]]
@@ -47,8 +47,8 @@
        (finally
          (alter-var-root #'trace/trace-enabled? (constantly false))))))
 
-(deftest handle-skips-new-dispatch-id-when-tracing-off
-  (testing "re-frame.events/handle MUST NOT call (new-dispatch-id) when
+(deftest handle-skips-new-uuid-when-tracing-off
+  (testing "re-frame.events/handle MUST NOT call (new-uuid) when
             tracing is disabled — UUID generation is cryptographically
             expensive (SecureRandom on JVM) and must not run on every
             dispatch in production"
@@ -56,18 +56,18 @@
       (rf/reg-event-db
         :trace-zero/sink
         (fn [db _] (assoc db :touched true)))
-      (with-redefs [events/new-dispatch-id (fn [] (swap! calls inc) (java.util.UUID/randomUUID))]
+      (with-redefs [interop/new-uuid (fn [] (swap! calls inc) (java.util.UUID/randomUUID))]
         (alter-var-root #'trace/trace-enabled? (constantly false))
         (rf/dispatch-sync [:trace-zero/sink])
         (is (zero? @calls)
-            "with tracing off, (new-dispatch-id) is not called — the cost
+            "with tracing off, (new-uuid) is not called — the cost
              of trace-tag UUID generation belongs only on the trace path")
 
         (with-tracing-on
           (reset! calls 0)
           (rf/dispatch-sync [:trace-zero/sink])
           (is (= 1 @calls)
-              "with tracing on, (new-dispatch-id) IS called exactly once
+              "with tracing on, (new-uuid) IS called exactly once
                per handle — confirms the gate flips work back on (the
                test is meaningful, not always-zero by accident)"))))))
 

--- a/test/re_frame/trace_zero_cost_test.clj
+++ b/test/re_frame/trace_zero_cost_test.clj
@@ -1,10 +1,10 @@
 (ns re-frame.trace-zero-cost-test
-  "Asserts that the trace machinery added by rf-3p7 (auto :dispatch-id +
+  "Asserts that trace-only bookkeeping (auto :dispatch-id +
    :input-query-vs) is INERT when tracing is disabled.
 
-   The af024c3 commit introduced a fresh UUID per `re-frame.events/handle`
-   call; the fa90f70 commit added an atom deref + `mapv` per
-   `deref-input-signals` call. Both were initially unconditional —
+   Dispatch tracing allocates a fresh UUID per `re-frame.events/handle`
+   call; subscription tracing walks input signals in
+   `deref-input-signals`. Both were initially unconditional —
    contradicting re-frame's load-bearing guarantee that tracing-off ==
    zero cost. Subs re-run on every transitive deref change and dispatches
    fire on every user action, so even a few microseconds per call shows

--- a/test/re_frame/validate_trace_test.clj
+++ b/test/re_frame/validate_trace_test.clj
@@ -19,6 +19,7 @@
    empty."
   (:require [clojure.test     :refer [deftest is testing use-fixtures]]
             [re-frame.core    :as rf]
+            [re-frame.interop :as interop]
             [re-frame.loggers :as loggers]
             [re-frame.trace   :as trace]))
 
@@ -53,6 +54,22 @@
      (try ~@body
           (finally
             (alter-var-root #'trace/trace-enabled? (constantly false))))))
+
+(deftest finish-trace-end-and-duration-use-same-clock-read
+  (testing "finished traces keep :end, :start, and :duration self-consistent"
+    (let [ticks (atom [100 125 999])]
+      (with-redefs [interop/now (fn []
+                                  (let [n (first @ticks)]
+                                    (swap! ticks rest)
+                                    n))
+                    trace/run-tracing-callbacks! (fn [_])]
+        (with-tracing-on
+          (trace/with-trace {:operation ::timed :op-type :sync})
+          (let [{:keys [start end duration]} (last @trace/traces)]
+            (is (= 100 start))
+            (is (= 125 end))
+            (is (= 25 duration))
+            (is (= duration (- end start)))))))))
 
 (defn- capture-trace-warns
   "Run `f` with `:warn` redirected to a collector that keeps only

--- a/test/re_frame/validate_trace_test.clj
+++ b/test/re_frame/validate_trace_test.clj
@@ -17,7 +17,8 @@
    dispatch + 1-arity-subscribe + 2-arity-dynv-subscribe paths, filter
    the captured warns for the `re-frame.trace:` prefix, and assert
    empty."
-  (:require [clojure.test     :refer [deftest is testing use-fixtures]]
+  (:require [clojure.set      :as set]
+            [clojure.test     :refer [deftest is testing use-fixtures]]
             [re-frame.core    :as rf]
             [re-frame.interop :as interop]
             [re-frame.loggers :as loggers]
@@ -42,6 +43,20 @@
         (restore)))))
 
 (use-fixtures :each fixture-clean-state)
+
+(deftest tag-schema-covers-re-frame-emitted-op-types
+  (testing "tag-schema includes every op-type emitted by re-frame core"
+    (let [emitted #{:event
+                    :event/handler
+                    :event/do-fx
+                    :sync
+                    :re-frame.router/fsm-trigger
+                    :flow
+                    :sub/create
+                    :sub/run
+                    :sub/dispose
+                    :reagent/quiescent}]
+      (is (empty? (set/difference emitted (set (keys trace/tag-schema))))))))
 
 (defmacro ^:private with-tracing-on
   "Flip `trace-enabled?` true for the body and restore on exit. The

--- a/test/re_frame/validate_trace_test.clj
+++ b/test/re_frame/validate_trace_test.clj
@@ -58,6 +58,15 @@
                     :reagent/quiescent}]
       (is (empty? (set/difference emitted (set (keys trace/tag-schema))))))))
 
+(deftest tag-schema-entries-have-contract-shape
+  (testing "each tag-schema entry carries the documented keys"
+    (doseq [[op schema] trace/tag-schema]
+      (is (set/subset? #{:required :optional :doc} (set (keys schema)))
+          (str op " schema should expose required, optional, and doc"))
+      (is (set? (:required schema)) (str op " :required should be a set"))
+      (is (set? (:optional schema)) (str op " :optional should be a set"))
+      (is (string? (:doc schema)) (str op " :doc should be a string")))))
+
 (defmacro ^:private with-tracing-on
   "Flip `trace-enabled?` true for the body and restore on exit. The
    var is also reset by the fixture, but flipping it locally keeps
@@ -72,7 +81,7 @@
 
 (deftest finish-trace-end-and-duration-use-same-clock-read
   (testing "finished traces keep :end, :start, and :duration self-consistent"
-    (let [ticks (atom [100 125 999])]
+    (let [ticks (atom (concat [100 125] (repeat 125)))]
       (with-redefs [interop/now (fn []
                                   (let [n (first @ticks)]
                                     (swap! ticks rest)
@@ -108,6 +117,39 @@
          (finally
            (loggers/set-loggers! {:warn prev-warn})))
     @warns))
+
+(deftest set-validate-trace-flips-predicate
+  (testing "set-validate-trace! controls validate-trace?"
+    (trace/set-validate-trace! false)
+    (is (false? (trace/validate-trace?)))
+    (trace/set-validate-trace! true)
+    (is (true? (trace/validate-trace?)))))
+
+(deftest check-trace-against-schema-warning-paths
+  (testing "missing required tag keys warn"
+    (let [warns (capture-trace-warns
+                 #(trace/check-trace-against-schema
+                   {:id 1 :op-type :event :tags {}}))]
+      (is (= 1 (count warns)))
+      (is (re-find #"missing required tag key" (first warns)))
+      (is (re-find #":event" (first warns)))))
+
+  (testing "unknown tag keys warn"
+    (let [warns (capture-trace-warns
+                 #(trace/check-trace-against-schema
+                   {:id      2
+                    :op-type :event
+                    :tags    {:event [:ok]
+                              :totally-bogus 42}}))]
+      (is (= 1 (count warns)))
+      (is (re-find #"unknown tag key" (first warns)))
+      (is (re-find #":totally-bogus" (first warns)))))
+
+  (testing "unknown op-types stay unconstrained"
+    (let [warns (capture-trace-warns
+                 #(trace/check-trace-against-schema
+                   {:id 3 :op-type :third-party/whatever :tags {}}))]
+      (is (empty? warns)))))
 
 (deftest no-warns-on-event-and-event-handler
   (testing "set-validate-trace! true does not warn on the :event,


### PR DESCRIPTION
## Summary

Bundles the recent local work in `re-frame` for review.

## Commit Range

- Base: `origin/master`
- Commits: `26`

## Recent Commits

- 795505a ci: forward browser test chrome path
- 69dedcc fix: use daemon thread for JVM next-tick
- 784b885 fix: prefer form metadata for macro source files
- d459e67 test: cover dispatch settle edge cases
- 5e516af perf: make trace validation flag direct
- 835edce test: cover trace schema validation
- c6bfce7 docs: cross-reference trace helper APIs
- faefc66 test: cover subscription input query traces
- 12503f1 test: cover emitted trace op schemas
- d27c243 docs: remove stale trace planning references
- c618477 refactor: share event metadata inheritance
- 34dce19 refactor: use callback for dispatch id capture
- 617f509 fix: avoid metadata tagging crashes
- 95d2f10 fix: keep finished trace timestamps consistent
- 3f73e36 refactor: share uuid helper through interop
- bb5e2ed fix: support dynv subscribe macro arity
- c73d174 fix: resolve dispatch-and-settle with cljs data
- 76204ce refactor: dedupe reg-event-* macros and runtime fns (rf-3aa)
- cf99293 test: cover dispatch-with / dispatch-sync-with overrides (rf-bt9)
- 5128e25 refactor: dedupe dispatch/subscribe macro bodies (rf-7za)

## Validation

- Not run as part of PR creation.
